### PR TITLE
33 update instance and work model timestamps to align with versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 The Blue Core Data Models are used in [Blue Core API](https://github.com/blue-core-lod/bluecore_api) 
 and in the [Blue Core Workflows](https://github.com/blue-core-lod/bluecore-workflows) services.  
 
-## Run Postgres with Docker
+## 🐳 Run Postgres with Docker
 To run the Postgres with the Blue Core Database, run the following command from this directory:
 
 `docker run --name bluecore_db -e POSTGRES_USER=bluecore_admin -e POSTGRES_PASSWORD=bluecore_admin -v ./create-db.sql:/docker-entrypoint-initdb.d/create_database.sql -p 5432:5432 postgres:17`
 
-## Installing
+---
+
+## 🛠️ Installing
 - Install via pip: `pip install bluecore-models`
 - Install via uv: `uv add bluecore-models`
 
-## Database Management
+---
+
+## 🗄️ Database Management
 The [SQLAlchemy](https://www.sqlalchemy.org/) Object Relational Mapper (ORM) is used to create
 the Bluecore database models. 
 
@@ -45,7 +49,29 @@ to add the new script to the repository with `git`.
 To apply all of the migrations, run the following command:
 - `uv run alembic upgrade head`
 
-## Publishing to Pypi
+---
+
+## 🧪 Running Tests
+The test suite is written using pytest and is executed via uv.
+All tests are located in the tests/ directory.
+
+#### Run All Tests
+`uv run pytest`
+
+#### Run a specific test file
+`uv run pytest tests/test_models.py`
+
+#### Run a specific test function
+`uv run pytest tests/test_models.py -k test_updated_instance`
+
+#### Show output (prints/logs) during test execution
+`uv run pytest -s`
+
+💡 Make sure your virtual environment is activated and dependencies are installed with uv before running tests.
+
+---
+
+## ⬆️ Publishing to Pypi
 To publish the `bluecore-models` to [pypi](https://pypi.org/project/bluecore-models/), the
 following steps need to be taken. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.4.2"
+version = "0.4.3"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/models/instance.py
+++ b/src/bluecore_models/models/instance.py
@@ -45,6 +45,7 @@ def create_version_bf_classes(mapper, connection, target):
     stmt = insert(Version.__table__).values(
         resource_id=target.id,
         data=target.data,
+        created_at=target.updated_at,
     )
     connection.execute(stmt)
     add_bf_classes(connection, target)
@@ -58,6 +59,7 @@ def update_version_bf_classes(mapper, connection, target):
     stmt = insert(Version.__table__).values(
         resource_id=target.id,
         data=target.data,
+        created_at=target.updated_at,
     )
     connection.execute(stmt)
     update_bf_classes(connection, target)

--- a/src/bluecore_models/models/work.py
+++ b/src/bluecore_models/models/work.py
@@ -37,6 +37,7 @@ def create_version_bf_classes(mapper, connection, target):
     stmt = insert(Version.__table__).values(
         resource_id=target.id,
         data=target.data,
+        created_at=target.updated_at,
     )
     connection.execute(stmt)
     add_bf_classes(connection, target)
@@ -50,6 +51,7 @@ def update_version_bf_classes(mapper, connection, target):
     stmt = insert(Version.__table__).values(
         resource_id=target.id,
         data=target.data,
+        created_at=target.updated_at,
     )
     connection.execute(stmt)
     update_bf_classes(connection, target)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,6 +117,9 @@ def test_resource_bibframe_class(pg_session):
 def test_instance(pg_session):
     with pg_session() as session:
         instance = session.query(Instance).where(Instance.id == 2).first()
+        version = session.query(Version).filter_by(resource_id=instance.id).first()
+        assert instance.created_at == instance.updated_at
+        assert version.created_at == instance.updated_at
         assert instance.uri.startswith("https://bluecore.info/instance")
         assert instance.data
         assert instance.created_at

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -133,6 +133,9 @@ def test_instance(pg_session):
 def test_work(pg_session):
     with pg_session() as session:
         work = session.query(Work).where(Work.id == 1).first()
+        version = session.query(Version).filter_by(resource_id=work.id).first()
+        assert work.created_at == work.updated_at
+        assert version.created_at == work.updated_at
         assert work.uri.startswith("https://bluecore.info/work")
         assert work.data
         assert work.created_at

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,8 @@ from bluecore_models.utils.graph import BF, init_graph
 
 
 def create_test_rows():
+    time_now = datetime.now(UTC)  # Use for Instance and Work for now
+
     return Rows(
         # BibframeClass
         BibframeClass(
@@ -43,8 +45,8 @@ def create_test_rows():
         Work(
             id=1,
             uri="https://bluecore.info/works/23db8603-1932-4c3f-968c-ae584ef1b4bb",
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
+            created_at=time_now,
+            updated_at=time_now,
             data=pathlib.Path("tests/blue-core-work.jsonld").read_text(),
             type="works",
         ),
@@ -52,8 +54,8 @@ def create_test_rows():
         Instance(
             id=2,
             uri="https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
+            created_at=time_now,
+            updated_at=time_now,
             data=pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
             type="instances",
             work_id=1,

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -17,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.4.1"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Updates
* bluecore-models version bump to 0.4.3
* Used `created_at=target.updated_at` to ensure created `versions` timestamps align with updated `works` and `instances` (version `created_at` column should equal instance `updated_at` column)
* Updated tests to ensure timestamps are aligned as intended
* Updated README
