### PR TITLE
Replaces External Subject with BlueCore URI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",
+    "pytest-mock>=3.14.1",
     "pytest-mock-resources>=2.12.1",
     "ruff>=0.9.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.5.1"
+version = "0.6.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,10 +79,14 @@ def test_generate_other_resources():
 
 
 def test_handle_external_bnode_subject(mocker):
-    mocker.patch("bluecore_models.utils.uuid4",
-                 return_value="ac35fae6-3727-11f0-a057-5a0f9a6cb774")
-    
-    work_uri = rdflib.URIRef("https://bcld.info/works/c35fae6-3727-11f0-a057-5a0f9a6cb774")
+    mocker.patch(
+        "bluecore_models.utils.graph.uuid4",
+        return_value="ac35fae6-3727-11f0-a057-5a0f9a6cb774",
+    )
+
+    work_uri = rdflib.URIRef(
+        "https://bcld.info/works/ac35fae6-3727-11f0-a057-5a0f9a6cb774"
+    )
     graph = init_graph()
     subject = rdflib.BNode()
     graph.add((subject, rdflib.RDF.type, BF.Work))
@@ -92,16 +96,19 @@ def test_handle_external_bnode_subject(mocker):
 
     result = handle_external_subject(
         bluecore_base_url="https://bcld.info/",
-        data=graph.serialize(format='jsonld'),
-        type="works"
+        data=graph.serialize(format="json-ld"),
+        type="works",
     )
 
-    assert result['uri'] == str(work_uri)
+    assert result["uri"] == str(work_uri)
     bluecore_graph = init_graph()
-    bluecore_graph.parse(data=result['data'], format='jsonld')
+    bluecore_graph.parse(data=result["data"], format="json-ld")
 
     bluecore_title = bluecore_graph.value(subject=work_uri, predicate=BF.title)
-    assert str(bluecore_graph.value(subject=bluecore_title, predicate=BF.mainTitle)) == "A Testing Work"
+    assert (
+        str(bluecore_graph.value(subject=bluecore_title, predicate=BF.mainTitle))
+        == "A Testing Work"
+    )
 
 
 def test_is_work_or_instance():

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "pytest-mock-resources" },
     { name = "ruff" },
 ]
@@ -43,6 +44,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "pytest-mock-resources", specifier = ">=2.12.1" },
     { name = "ruff", specifier = ">=0.9.6" },
 ]
@@ -219,6 +221,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Supports API ticket https://github.com/blue-core-lod/bluecore_api/issues/75 so that the incoming RDF's subject URIs/blank nodes are replaced in the RDF. This functionality will also be used in the bluecore-workflows when doing batch ingestion.