### PR TITLE
Use Airflow login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and in the [Blue Core Workflows](https://github.com/blue-core-lod/bluecore-workf
 ## 🐳 Run Postgres with Docker
 To run the Postgres with the Blue Core Database, run the following command from this directory:
 
-`docker run --name bluecore_db -e POSTGRES_USER=bluecore_admin -e POSTGRES_PASSWORD=bluecore_admin -v ./create-db.sql:/docker-entrypoint-initdb.d/create_database.sql -p 5432:5432 postgres:17`
+`docker run --name bluecore_db -e POSTGRES_USER=airflow -e POSTGRES_PASSWORD=airflow -v ./create-db.sql:/docker-entrypoint-initdb.d/create_database.sql -p 5432:5432 postgres:17`
 
 ---
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql+psycopg2://bluecore_admin:bluecore_admin@localhost/bluecore
+sqlalchemy.url = postgresql+psycopg2://airflow:airflow@localhost/bluecore
 
 
 [post_write_hooks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.6.0"
+version = "0.6.1"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Current docker stack uses the airflow user for the login, changes `alembic.ini` to reflect this practice.