### PR TITLE
Store json-ld dict instead of str

### DIFF
--- a/src/bluecore_models/utils/graph.py
+++ b/src/bluecore_models/utils/graph.py
@@ -183,7 +183,7 @@ def get_bf_classes(rdf_data: str, uri: str) -> list:
     return classes
 
 
-def frame_jsonld(bluecore_uri: str, graph: rdflib.Graph):
+def frame_jsonld(bluecore_uri: str, graph: rdflib.Graph) -> dict:
     """Frames the JSON-LD data to a specific structure."""
     context: Dict[str, str] = {
         "@vocab": "http://id.loc.gov/ontologies/bibframe/",
@@ -222,6 +222,6 @@ def handle_external_subject(**kwargs) -> dict:
 
     return {
         "uri": bluecore_uri,
-        "data": json.dumps(framed_data, indent=2),
+        "data": framed_data,
         "uuid": uuid,
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-import json
-
 import pathlib
 
 import rdflib
@@ -111,7 +109,7 @@ def test_handle_external_bnode_subject(mocker):
         == "A Testing Work"
     )
 
-    framed_doc = json.loads(result["data"])
+    framed_doc = result["data"]
     assert framed_doc["@context"]["@vocab"] == "http://id.loc.gov/ontologies/bibframe/"
     assert framed_doc["title"]["mainTitle"] == "A Testing Work"
 


### PR DESCRIPTION
We need to persist JSON-LD as a dictionary instead of a string to the JSONB column in order to query the structure using JSON Paths.

I believe we may also need to address this in bluecore-workflows where it talks directly to the database? But maybe not.

This change may also impact the pydantic schema used for works and instances in bluecore_api?

Fixes #51
