### PR TITLE
Better JSON-LD framing errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.8.0"
+version = "0.8.1"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/models/work.py
+++ b/src/bluecore_models/models/work.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sqlalchemy import (
     event,
     insert,
@@ -14,8 +12,7 @@ from sqlalchemy.orm import (
 
 from bluecore_models.models.resource import ResourceBase
 from bluecore_models.models.version import Version
-from bluecore_models.utils.db import add_bf_classes, update_bf_classes
-from bluecore_models.utils.graph import frame_jsonld
+from bluecore_models.utils.db import add_bf_classes, update_bf_classes, set_jsonld
 
 
 class Work(ResourceBase):
@@ -32,15 +29,7 @@ class Work(ResourceBase):
         return f"<Work {self.uri}>"
 
 
-@event.listens_for(Work.data, "set", propagate=True, retval=True)
-def set_jsonld(target, value, oldvalue, initiator) -> Optional[dict]:
-    """
-    Ensure that JSON-LD data is framed prior to persisting it to the database.
-    """
-    if value is not None:
-        return frame_jsonld(target.uri, value)
-    else:
-        return None
+event.listen(Work.data, "set", set_jsonld, retval=True)
 
 
 @event.listens_for(Work, "after_insert")

--- a/src/bluecore_models/utils/db.py
+++ b/src/bluecore_models/utils/db.py
@@ -1,11 +1,12 @@
 """Utilities for working with Blue Core Database"""
 
+from typing import Optional
+
 import rdflib
-
 from sqlalchemy import delete, insert, select
-from bluecore_models.models.bf_classes import BibframeClass, ResourceBibframeClass
 
-from bluecore_models.utils.graph import get_bf_classes
+from bluecore_models.models.bf_classes import BibframeClass, ResourceBibframeClass
+from bluecore_models.utils.graph import get_bf_classes, frame_jsonld
 
 
 def _new_bf_classs(connection, bf_class: rdflib.URIRef) -> int:
@@ -64,3 +65,28 @@ def update_bf_classes(connection, resource):
             bf_class_id=bf_class_id, resource_id=resource.id
         )
         connection.execute(stmt)
+
+
+def set_jsonld(target, value, oldvalue, initiator) -> Optional[dict]:
+    """
+    A ORM event handler that ensures JSON-LD data is framed prior to persisting it
+    to the database. Note the ordering of properties used in constructors
+    matters, since target.uri must be set on the object prior to setting data.
+
+    So this will work:
+
+        >>> w = Work(uri="https://example.com", data={ ... })
+
+    but this will not:
+
+        >>> w = Work(data={...}, uri="https://example.com")
+
+    """
+    if target.uri is None and value is not None:
+        raise ValueError(
+            "For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object."
+        )
+    elif value is not None:
+        return frame_jsonld(target.uri, value)
+    else:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -207,3 +207,30 @@ def test_other_resource_jsonld_framing():
         data=other_json,
     )
     assert other_json == other.data, "setting OtherResource.data DOES NOT frame json-ld"
+
+
+def test_property_order():
+    """
+    The JSON-LD stored in the data property is automatically "framed" when it is
+    set. But framing requires that a uri be defined already. These tests ensure
+    that a descriptive exception is thrown when the ordering is incorrect.
+    """
+    with pytest.raises(ValueError) as e:
+        Instance(
+            data={"foo": "bar"},
+            uri="https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
+        )
+    assert (
+        str(e.value)
+        == "For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object."
+    )
+
+    with pytest.raises(ValueError) as e:
+        Work(
+            data={"foo": "bar"},
+            uri="https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
+        )
+    assert (
+        str(e.value)
+        == "For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object."
+    )


### PR DESCRIPTION
When `Work.data` or `Instance.data` are set a SQLAlchemy event ensures that the JSON-LD data is "framed". For it to do this the `uri` property must also be set:

https://github.com/blue-core-lod/bluecore-models/blob/c69bc725793055858cae31b0db9926b1edf45ccf/src/bluecore_models/utils/db.py#L70-L92

We had some cases where data was being set before uri, which was causing a very difficult to interpret error message from deep in the guts of [pyld](https://pypi.org/project/PyLD/). This PR adds an exception message to help better understand the error.

This works fine (the order of the properties matters):

```python
Work(uri="https://example.com/", data={...})
```

but this does not:

```python
Work(data={...}, uri="https://example.com/")
```

which will now throw this exception:

```text
ValueError: For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object.
```

Since this behavior needed better documentation, and needed to be identical for `Work` and `Instance` I put the function in one place in `bluecore_models.utils.db` and used it from `Work` and `Instance`.
