### PR TITLE
46 add user id to versions

### DIFF
--- a/bluecore_models_migration/versions/da65046e4024_add_keycloak_user_id_to_versions.py
+++ b/bluecore_models_migration/versions/da65046e4024_add_keycloak_user_id_to_versions.py
@@ -1,0 +1,37 @@
+"""Add Keycloak user id to versions
+
+Revision ID: da65046e4024
+Revises: ad784bf46c6f
+Create Date: 2025-09-29 07:43:07.109100
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "da65046e4024"
+down_revision: Union[str, None] = "ad784bf46c6f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add keycloak_user_id column
+    op.add_column(
+        "versions",
+        sa.Column("keycloak_user_id", sa.String(length=128), nullable=True),
+    )
+    # Create a non-unique index to support lookups by user id
+    op.create_index(
+        "ix_versions_keycloak_user_id",
+        "versions",
+        ["keycloak_user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # Drop the index then the column
+    op.drop_index("ix_versions_keycloak_user_id", table_name="versions")
+    op.drop_column("versions", "keycloak_user_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.9.3"
+version = "0.9.4"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/models/version.py
+++ b/src/bluecore_models/models/version.py
@@ -8,7 +8,9 @@ from bluecore_models.models.base import Base
 from bluecore_models.models.resource import ResourceBase
 
 from contextvars import ContextVar
+
 CURRENT_USER_ID: ContextVar[str | None] = ContextVar("current_user_id", default=None)
+
 
 class Version(Base):
     __tablename__ = "versions"
@@ -19,7 +21,9 @@ class Version(Base):
     )
     resource: Mapped[ResourceBase] = relationship("ResourceBase", backref="versions")
     data: Mapped[bytes] = mapped_column(JSONB, nullable=False)
-    keycloak_user_id: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    keycloak_user_id: Mapped[str | None] = mapped_column(
+        String(128), index=True, nullable=True
+    )
     created_at = mapped_column(DateTime, default=datetime.utcnow)
 
     def __repr__(self):

--- a/src/bluecore_models/models/version.py
+++ b/src/bluecore_models/models/version.py
@@ -1,18 +1,14 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, ForeignKey
-
-from sqlalchemy.orm import (
-    mapped_column,
-    Mapped,
-    relationship,
-)
-
+from sqlalchemy import DateTime, Integer, ForeignKey, String
+from sqlalchemy.orm import mapped_column, Mapped, relationship
 from sqlalchemy.dialects.postgresql import JSONB
 
 from bluecore_models.models.base import Base
 from bluecore_models.models.resource import ResourceBase
 
+from contextvars import ContextVar
+CURRENT_USER_ID: ContextVar[str | None] = ContextVar("current_user_id", default=None)
 
 class Version(Base):
     __tablename__ = "versions"
@@ -23,7 +19,9 @@ class Version(Base):
     )
     resource: Mapped[ResourceBase] = relationship("ResourceBase", backref="versions")
     data: Mapped[bytes] = mapped_column(JSONB, nullable=False)
+    keycloak_user_id: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
     created_at = mapped_column(DateTime, default=datetime.utcnow)
 
     def __repr__(self):
-        return f"<Version at {self.created_at} for {self.resource.uri}>"
+        who = getattr(self, "keycloak_user_id", None) or "unknown"
+        return f"<Version at {self.created_at} by {who} for {self.resource.uri}>"

--- a/src/bluecore_models/utils/db.py
+++ b/src/bluecore_models/utils/db.py
@@ -7,7 +7,7 @@ from sqlalchemy import delete, insert, select
 from sqlalchemy.orm import object_session
 
 from bluecore_models.models.bf_classes import BibframeClass, ResourceBibframeClass
-from bluecore_models.models.version import Version
+from bluecore_models.models.version import Version, CURRENT_USER_ID
 from bluecore_models.utils.graph import get_bf_classes, frame_jsonld
 
 
@@ -38,10 +38,16 @@ def add_version(connection, resource):
     """
     Adds a Version if the resource had been modified.
     """
+    try:
+        uid = CURRENT_USER_ID.get()
+    except Exception:
+        uid = None
+
     if object_session(resource).is_modified(resource, include_collections=False):
         stmt = insert(Version.__table__).values(
             resource_id=resource.id,
             data=resource.data,
+            keycloak_user_id=uid,
             created_at=resource.updated_at,
         )
         connection.execute(stmt)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pathlib
 from datetime import datetime, UTC
 from uuid import UUID
 
+import contextlib
 import pytest
 
 from pytest_mock_resources import create_postgres_fixture, Rows, PostgresConfig
@@ -19,7 +20,6 @@ from bluecore_models.models import (
     Work,
     BibframeOtherResources,
 )
-
 
 def create_test_rows():
     time_now = datetime.now(UTC)  # Use for Instance and Work for now
@@ -75,3 +75,15 @@ engine = create_postgres_fixture(create_test_rows())
 def pg_session(engine):
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)
+
+@pytest.fixture
+def user_context():
+    from bluecore_models.models.version import CURRENT_USER_ID
+    @contextlib.contextmanager
+    def _context(uid: str | None):
+        token = CURRENT_USER_ID.set(uid)
+        try:
+            yield
+        finally:
+            CURRENT_USER_ID.reset(token)
+    return _context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from bluecore_models.models import (
     BibframeOtherResources,
 )
 
+
 def create_test_rows():
     time_now = datetime.now(UTC)  # Use for Instance and Work for now
 
@@ -76,9 +77,11 @@ def pg_session(engine):
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)
 
+
 @pytest.fixture
 def user_context():
     from bluecore_models.models.version import CURRENT_USER_ID
+
     @contextlib.contextmanager
     def _context(uid: str | None):
         token = CURRENT_USER_ID.set(uid)
@@ -86,4 +89,5 @@ def user_context():
             yield
         finally:
             CURRENT_USER_ID.reset(token)
+
     return _context

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,15 +101,19 @@ def test_versions(pg_session, user_context):
         instance = session.query(Instance).where(Instance.id == 2).first()
         assert version2.resource == instance
 
-        # Create a NEW version while a user UID is set in the ContextVar
-        from uuid import uuid4
         with user_context("55875c9a-c67c-4c60-9c91-bc260f71f92a"):
-            work.data = {**work.data, "_test_bump": uuid4().hex}
+            work.data = {**work.data, "_test_bump": uuid1().hex}
             session.add(work)
             session.commit()
-        latest_version = (session.query(Version).filter(Version.resource_id == work.id).order_by(Version.id.desc()).first())
+        latest_version = (
+            session.query(Version)
+            .filter(Version.resource_id == work.id)
+            .order_by(Version.id.desc())
+            .first()
+        )
         assert latest_version is not None
         assert latest_version.keycloak_user_id == "55875c9a-c67c-4c60-9c91-bc260f71f92a"
+
 
 def test_bibframe_other_resources(pg_session):
     with pg_session() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
**PR summary: Track Keycloak user on every Version + tests + release bump** 

### Changes

- **DB migration**: Add `versions.keycloak_user_id`

- **Model**:
  - `Version` now has `keycloak_user_id: Optional[str]` (indexed)

- **Request → DB plumbing**:
  - Introduce request-scoped `ContextVar`: `CURRENT_USER_ID`
  - `utils/db.py::add_version()` now reads `CURRENT_USER_ID.get()` and passes it into the raw `INSERT` so versions created by ORM events carry the **Keycloak uid**

- **Tests**:
  - Add `user_context` fixture (context manager) to set/reset `CURRENT_USER_ID`
  - Update `test_versions` to:
    1) mutate a `Work`
    2) commit inside `with user_context("<known-uid>")`
    3) assert the latest `Version.keycloak_user_id` == that uid

- **Packaging**:
  - Bump `bluecore-models` to **0.9.4**

### Backward compatibility / safety
- Column is **nullable** → existing rows remain valid.
- Reads are unchanged.
- If `CURRENT_USER_ID` is not set (e.g., scripts), `keycloak_user_id` stays `NULL`.

### Operational notes
- Run Alembic migration: `alembic upgrade head`.
- `bluecore_api` and `workflows` PRs are in progress and needed to utilize this PR functionality


