### PR TITLE
Do not frame "profile" Other Resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.10.0"
+version = "0.10.1"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/models/instance.py
+++ b/src/bluecore_models/models/instance.py
@@ -18,7 +18,6 @@ from bluecore_models.utils.db import (
     add_bf_classes,
     add_version,
     update_bf_classes,
-    set_jsonld,
 )
 
 
@@ -57,6 +56,3 @@ def update_version_bf_classes(mapper, connection, target):
     """
     add_version(connection, target)
     update_bf_classes(connection, target)
-
-
-event.listen(Instance.data, "set", set_jsonld, retval=True)

--- a/src/bluecore_models/models/other_resource.py
+++ b/src/bluecore_models/models/other_resource.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, ForeignKey, event
+from sqlalchemy import Boolean, DateTime, Integer, ForeignKey
 
 from sqlalchemy.orm import (
     mapped_column,
@@ -10,7 +10,6 @@ from sqlalchemy.orm import (
 
 from bluecore_models.models.base import Base
 from bluecore_models.models.resource import ResourceBase
-from bluecore_models.utils.db import set_jsonld
 
 
 class OtherResource(ResourceBase):
@@ -30,10 +29,6 @@ class OtherResource(ResourceBase):
 
     def __repr__(self):
         return f"<OtherResource {self.uri or self.id}>"
-
-
-# normalize JSON-LD as it is saved to the database
-event.listen(OtherResource.data, "set", set_jsonld, retval=True)
 
 
 class BibframeOtherResources(Base):

--- a/src/bluecore_models/models/resource.py
+++ b/src/bluecore_models/models/resource.py
@@ -1,8 +1,12 @@
-from datetime import datetime, UTC
-from sqlalchemy import DateTime, String, Uuid, Computed, event, text
-from sqlalchemy.orm import mapped_column, Mapped
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlalchemy import Computed, DateTime, String, Uuid, event, text
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
+from sqlalchemy.orm import Mapped, mapped_column
+
 from bluecore_models.models.base import Base
+from bluecore_models.utils.graph import frame_jsonld
 
 
 class ResourceBase(Base):
@@ -42,3 +46,37 @@ def set_created_and_updated(mapper, connection, target):
         target.created_at = now
     if not target.updated_at:
         target.updated_at = now
+
+
+def set_jsonld(target, value, oldvalue, initiator) -> Optional[dict]:
+    """
+    An ORM event handler that ensures JSON-LD data is framed prior to persisting it
+    to the database. Note the ordering of properties used in constructors
+    matters, since target.uri must be set on the object prior to setting data.
+
+    Also, if it is an OtherResource that has is_profile set to True, the data
+    will not be framed, since it is not JSON-LD and has no uri.
+
+    So this will work:
+
+        >>> w = Work(uri="https://example.com", data={ ... })
+
+    but this will not:
+
+        >>> w = Work(data={...}, uri="https://example.com")
+
+    """
+    if hasattr(target, "is_profile") and target.is_profile is True:
+        return value
+    elif target.uri is None and value is not None:
+        raise ValueError(
+            "For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object."
+        )
+    elif value is not None:
+        return frame_jsonld(target.uri, value)
+    else:
+        return None
+
+
+# propagate=True lets this event fire for Work, Instance and OtherResource types
+event.listen(ResourceBase.data, "set", set_jsonld, retval=True, propagate=True)

--- a/src/bluecore_models/models/work.py
+++ b/src/bluecore_models/models/work.py
@@ -14,7 +14,6 @@ from bluecore_models.utils.db import (
     add_bf_classes,
     add_version,
     update_bf_classes,
-    set_jsonld,
 )
 
 
@@ -30,9 +29,6 @@ class Work(ResourceBase):
 
     def __repr__(self):
         return f"<Work {self.uri}>"
-
-
-event.listen(Work.data, "set", set_jsonld, retval=True)
 
 
 @event.listens_for(Work, "after_insert")

--- a/src/bluecore_models/utils/db.py
+++ b/src/bluecore_models/utils/db.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 import rdflib
 from sqlalchemy import delete, insert, select
 from sqlalchemy.orm import object_session
 
 from bluecore_models.models.bf_classes import BibframeClass, ResourceBibframeClass
 from bluecore_models.models.version import CURRENT_USER_ID, Version
-from bluecore_models.utils.graph import frame_jsonld, get_bf_classes
+from bluecore_models.utils.graph import get_bf_classes
 
 
 def _new_bf_classs(connection, bf_class: rdflib.URIRef) -> int:
@@ -84,28 +82,3 @@ def update_bf_classes(connection, resource):
             bf_class_id=bf_class_id, resource_id=resource.id
         )
         connection.execute(stmt)
-
-
-def set_jsonld(target, value, oldvalue, initiator) -> Optional[dict]:
-    """
-    A ORM event handler that ensures JSON-LD data is framed prior to persisting it
-    to the database. Note the ordering of properties used in constructors
-    matters, since target.uri must be set on the object prior to setting data.
-
-    So this will work:
-
-        >>> w = Work(uri="https://example.com", data={ ... })
-
-    but this will not:
-
-        >>> w = Work(data={...}, uri="https://example.com")
-
-    """
-    if target.uri is None and value is not None:
-        raise ValueError(
-            "For automatic jsonld framing to work you must ensure the uri property is set before the data property, even when constructing an object."
-        )
-    elif value is not None:
-        return frame_jsonld(target.uri, value)
-    else:
-        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -89,6 +89,20 @@ def test_other_resource(pg_session):
         assert other_resource.is_profile is False
 
 
+def test_other_resource_profile(pg_session):
+    """
+    OtherResource "profiles" are not framed since they aren't necessarily JSON-LD
+    and won't have a URI associated with them.
+    """
+    with pg_session() as session:
+        session.add(OtherResource(is_profile=True, data={"foo": "bar"}))
+        session.commit()
+
+    with pg_session() as session:
+        other = session.query(OtherResource).order_by(OtherResource.id).all()[-1]
+        assert other.data["foo"] == "bar"
+
+
 def test_versions(pg_session, user_context):
     with pg_session() as session:
         version = session.query(Version).where(Version.id == 1).first()

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.9.4"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This commit updates the automatic json-ld framing so that it does not run for OtherResource where is_profile is set to True. This is needed because "profile" OtherResources don't store json-ld in their data property, and framing it that way will cause problems.

Since we are framing the json-ld for Work, Instance and OtherResource objects the functionality and event listener were moved to BaseResource.
