### PR TITLE
Prevent infinite recursion in _expand_bnode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.11.2"
+version = "0.11.3"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/utils/graph.py
+++ b/src/bluecore_models/utils/graph.py
@@ -77,8 +77,14 @@ def _exclude_uri_from_other_resources(uri: Node) -> bool:
     return uri in BF or uri in MADS or uri in RDF  # type: ignore
 
 
-def _expand_bnode(graph: Graph, entity_graph: Graph, bnode: BNode):
+def _expand_bnode(graph: Graph, entity_graph: Graph, bnode: BNode) -> None:
     """Expand a blank node in the entity graph."""
+
+    # if the blank node is already present in the entity graph there's no need to add it
+    # this prevents infinite recursion
+    if bnode in entity_graph.subjects():
+        return
+
     for pred, obj in graph.predicate_objects(subject=bnode):
         if _check_for_namespace(pred) or _check_for_namespace(obj):
             continue

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 import rdflib
-from rdflib import URIRef
+from rdflib import URIRef, Literal, DCTERMS
 
 from bluecore_models.utils.graph import (
     BF,
@@ -13,6 +13,7 @@ from bluecore_models.utils.graph import (
     handle_external_subject,
     init_graph,
     load_jsonld,
+    _expand_bnode,
     _is_work_or_instance,
 )
 
@@ -96,7 +97,7 @@ def test_handle_external_bnode_subject(mocker):
     graph.add((subject, rdflib.RDF.type, BF.Work))
     title_bnode = rdflib.BNode()
     graph.add((subject, BF.title, title_bnode))
-    graph.add((title_bnode, BF.mainTitle, rdflib.Literal("A Testing Work")))
+    graph.add((title_bnode, BF.mainTitle, Literal("A Testing Work")))
 
     result = handle_external_subject(
         bluecore_base_url="https://bcld.info/",
@@ -121,3 +122,41 @@ def test_is_work_or_instance():
     loc_graph.add((work_uri, rdflib.RDF.type, MADS.Resource))
     loc_graph.add((work_uri, rdflib.RDF.type, BF.Work))
     assert _is_work_or_instance(work_uri, loc_graph)
+
+
+def test_bnode_expansion():
+    """
+    When Work and Instances refer to each other as BNodes we need to ensure we
+    don't get caught in infinite recursion.
+    """
+
+    batch_graph = init_graph()
+    entity_graph = init_graph()
+
+    work_bnode = rdflib.BNode()
+    instance_bnode = rdflib.BNode()
+
+    # add six assertions for the work and instance that are linked together as bnodes
+    batch_graph.add((work_bnode, rdflib.RDF.type, BF.Work))
+    batch_graph.add((work_bnode, BF.hasInstance, instance_bnode))
+    batch_graph.add((work_bnode, BF.acquisitionTerms, Literal("(b&w film copy neg.)")))
+    batch_graph.add((instance_bnode, rdflib.RDF.type, BF.Instance))
+    batch_graph.add((instance_bnode, BF.instanceOf, work_bnode))
+    batch_graph.add((work_bnode, BF.dimensions, Literal("28 cm")))
+
+    # add two assertions that should be ignored because they are in DCTERMS
+    batch_graph.add(
+        (work_bnode, DCTERMS.title, Literal("Ignored DublinCore title for work"))
+    )
+    batch_graph.add(
+        (
+            instance_bnode,
+            DCTERMS.title,
+            Literal("Ignored DublinCore title for instance"),
+        )
+    )
+
+    # populate entity_graph using the batch_graph
+    _expand_bnode(batch_graph, entity_graph, work_bnode)
+
+    assert len(entity_graph) == 6, "DCTERMS assertions should be ignored"


### PR DESCRIPTION
We don't need to expand blank nodes that are already present in the entity graph.

I think (but didn't confirm) that we started seeing these recently because we are now inferring `rdf:type`, `bf:hasInstance` and `bf:instanceOf` assertions in #82.

Fixes #84
