### PR TITLE
Handles Graph Deadlocks when Saving Multiple Graphs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.12.1"
+version = "0.13.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pyld>=2.0.4",
     "pymilvus[model,milvus_lite]",
     "rdflib>=7.1.3",
+    "tenacity>=9.1.4",
     "transformers==4.57.5", # pinned until pymilvus works with transformers v5
 ]
 

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -2,8 +2,10 @@ import json
 import logging
 from uuid import uuid4
 
+from psycopg2 import errors as psycopg2_errors
 from rdflib import Graph, URIRef, Namespace, Node, IdentifiedNode
 from rdflib.plugins import sparql
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import sessionmaker, Session
 
 from bluecore_models.namespaces import BF, MADS, RDF
@@ -12,6 +14,16 @@ from bluecore_models.utils.graph import generate_entity_graph
 
 
 logger = logging.getLogger(__name__)
+
+# Postgres errors that mean "the transaction lost a race and can be safely
+# retried by re-running it from the start" (a graph save is self-contained).
+RETRYABLE_PG_ERRORS = (
+    psycopg2_errors.DeadlockDetected,
+    psycopg2_errors.SerializationFailure,
+)
+
+# How many times to attempt save() before giving up on serialization failures.
+SAVE_MAX_ATTEMPTS = 3
 
 
 def save_graph(
@@ -87,28 +99,48 @@ class BluecoreGraph:
         """
         return self._extract_others()
 
-    def save(self, session_maker: sessionmaker) -> None:
+    def save(
+        self, session_maker: sessionmaker, max_attempts: int = SAVE_MAX_ATTEMPTS
+    ) -> None:
         """
         Persists the graph to the database using the supplied sqlalchemy
         sessionmaker. All the database modifications are made using a single
         transaction.
+
+        Under concurrent writers a transaction can still lose a race and be
+        aborted by Postgres with a deadlock or serialization failure. Since a
+        graph save is self-contained and idempotent, we simply re-run the whole
+        thing on a fresh session up to max_attempts times.
         """
-        with session_maker() as session:
-            # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
-            # note: OtherResources keep their original URI
-            self._mint_all_uris(BF.Work, session)
-            self._mint_all_uris(BF.Instance, session)
+        for attempt in range(1, max_attempts + 1):
+            try:
+                with session_maker() as session:
+                    # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
+                    # note: OtherResources keep their original URI
+                    self._mint_all_uris(BF.Work, session)
+                    self._mint_all_uris(BF.Instance, session)
 
-            # save resources from the graph to the database
-            self._save(BF.Work, session)
-            self._save(BF.Instance, session)
-            self._save(None, session)  # there is no catchall URI for Other Resources
+                    # save resources from the graph to the database
+                    self._save(BF.Work, session)
+                    self._save(BF.Instance, session)
+                    self._save(None, session)  # there is no catchall URI for Other Resources
 
-            # link all the works, instances and other resources together in the db
-            self._link(session)
+                    # link all the works, instances and other resources together in the db
+                    self._link(session)
 
-            # all changes are part of one transaction!
-            session.commit()
+                    # all changes are part of one transaction!
+                    session.commit()
+                return
+            except OperationalError as error:
+                if attempt < max_attempts and isinstance(
+                    error.orig, RETRYABLE_PG_ERRORS
+                ):
+                    logger.warning(
+                        f"retrying graph save after {type(error.orig).__name__} "
+                        f"(attempt {attempt} of {max_attempts})"
+                    )
+                    continue
+                raise
 
     def _infer(self) -> None:
         """

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -7,6 +7,7 @@ from rdflib import Graph, URIRef, Namespace, Node, IdentifiedNode
 from rdflib.plugins import sparql
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm.session import sessionmaker, Session
+from tenacity import Retrying, retry_if_exception, stop_after_attempt
 
 from bluecore_models.namespaces import BF, MADS, RDF
 from bluecore_models.models import Work, Instance, OtherResource, BibframeOtherResources
@@ -28,6 +29,17 @@ RETRYABLE_PG_ERRORS = (
 
 # How many times to attempt save() before giving up on serialization failures.
 SAVE_MAX_ATTEMPTS = 3
+
+
+def _is_retryable_pg_error(error: BaseException) -> bool:
+    """
+    A graph save is only retried when Postgres aborted the transaction with one
+    of the retryable errors above (surfaced by sqlalchemy as an OperationalError
+    or IntegrityError wrapping the psycopg2 error in .orig).
+    """
+    return isinstance(error, (OperationalError, IntegrityError)) and isinstance(
+        error.orig, RETRYABLE_PG_ERRORS
+    )
 
 
 def save_graph(
@@ -116,38 +128,43 @@ class BluecoreGraph:
         graph save is self-contained and idempotent, we simply re-run the whole
         thing on a fresh session up to max_attempts times.
         """
-        for attempt in range(1, max_attempts + 1):
-            try:
-                with session_maker() as session:
-                    # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
-                    # note: OtherResources keep their original URI
-                    self._mint_all_uris(BF.Work, session)
-                    self._mint_all_uris(BF.Instance, session)
 
-                    # save resources from the graph to the database
-                    self._save(BF.Work, session)
-                    self._save(BF.Instance, session)
-                    self._save(
-                        None, session
-                    )  # there is no catchall URI for Other Resources
+        def log_retry(retry_state) -> None:
+            error = retry_state.outcome.exception()
+            logger.warning(
+                f"retrying graph save after {type(error.orig).__name__} "
+                f"(attempt {retry_state.attempt_number} of {max_attempts})"
+            )
 
-                    # link all the works, instances and other resources together in the db
-                    self._link(session)
+        try:
+            for attempt in Retrying(
+                retry=retry_if_exception(_is_retryable_pg_error),
+                stop=stop_after_attempt(max_attempts),
+                before_sleep=log_retry,
+                reraise=True,
+            ):
+                with attempt:
+                    with session_maker() as session:
+                        # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
+                        # note: OtherResources keep their original URI
+                        self._mint_all_uris(BF.Work, session)
+                        self._mint_all_uris(BF.Instance, session)
 
-                    # all changes are part of one transaction!
-                    session.commit()
-                return
-            except (OperationalError, IntegrityError) as error:
-                if attempt < max_attempts and isinstance(
-                    error.orig, RETRYABLE_PG_ERRORS
-                ):
-                    logger.warning(
-                        f"retrying graph save after {type(error.orig).__name__} "
-                        f"(attempt {attempt} of {max_attempts})"
-                    )
-                else:
-                    logger.error(f"Exceeded {max_attempts} attempts with error {error}")
-                    raise
+                        # save resources from the graph to the database
+                        self._save(BF.Work, session)
+                        self._save(BF.Instance, session)
+                        self._save(
+                            None, session
+                        )  # there is no catchall URI for Other Resources
+
+                        # link all the works, instances and other resources together in the db
+                        self._link(session)
+
+                        # all changes are part of one transaction!
+                        session.commit()
+        except (OperationalError, IntegrityError) as error:
+            logger.error(f"Exceeded {max_attempts} attempts with error {error}")
+            raise
 
     def _infer(self) -> None:
         """

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from psycopg2 import errors as psycopg2_errors
 from rdflib import Graph, URIRef, Namespace, Node, IdentifiedNode
 from rdflib.plugins import sparql
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm.session import sessionmaker, Session
 
 from bluecore_models.namespaces import BF, MADS, RDF
@@ -17,9 +17,16 @@ logger = logging.getLogger(__name__)
 
 # Postgres errors that mean "the transaction lost a race and can be safely
 # retried by re-running it from the start" (a graph save is self-contained).
+#
+# - DeadlockDetected / SerializationFailure: two writers locked shared rows in a
+#   conflicting way; Postgres aborted one of them.
+# - UniqueViolation: two writers both did get-or-create on the same brand-new
+#   shared Other Resource uri and both tried to INSERT it. On a retry the SELECT
+#   finds the row the winner committed and takes the update/no-op path instead.
 RETRYABLE_PG_ERRORS = (
     psycopg2_errors.DeadlockDetected,
     psycopg2_errors.SerializationFailure,
+    psycopg2_errors.UniqueViolation,
 )
 
 # How many times to attempt save() before giving up on serialization failures.
@@ -131,7 +138,7 @@ class BluecoreGraph:
                     # all changes are part of one transaction!
                     session.commit()
                 return
-            except OperationalError as error:
+            except (OperationalError, IntegrityError) as error:
                 if attempt < max_attempts and isinstance(
                     error.orig, RETRYABLE_PG_ERRORS
                 ):

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -127,7 +127,9 @@ class BluecoreGraph:
                     # save resources from the graph to the database
                     self._save(BF.Work, session)
                     self._save(BF.Instance, session)
-                    self._save(None, session)  # there is no catchall URI for Other Resources
+                    self._save(
+                        None, session
+                    )  # there is no catchall URI for Other Resources
 
                     # link all the works, instances and other resources together in the db
                     self._link(session)
@@ -438,16 +440,12 @@ class BluecoreGraph:
         self._delete_other_links(BF.Work, session)
         self._delete_other_links(BF.Instance, session)
 
-        work_graphs = sorted(
-            self.works(), key=lambda g: str(self._subject(g, BF.Work))
-        )
+        work_graphs = sorted(self.works(), key=lambda g: str(self._subject(g, BF.Work)))
         instance_graphs = sorted(
             self.instances(), key=lambda g: str(self._subject(g, BF.Instance))
         )
 
-        for other_graph in sorted(
-            self.others(), key=lambda g: str(self._subject(g))
-        ):
+        for other_graph in sorted(self.others(), key=lambda g: str(self._subject(g))):
             other_uri = self._subject(other_graph)
 
             # look at each Work graph and see if the Other Resource URI appears

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -329,6 +329,15 @@ class BluecoreGraph:
                 resources = self.others()
                 sqla_class = OtherResource
 
+        # Write shared Other Resources in a deterministic, sorted-by-URI order.
+        # Concurrent transactions then acquire locks on these hot rows in the
+        # same order and serialize instead of deadlocking. Works and Instances
+        # are distinct per file (and have randomly minted URIs), so they are
+        # left in their natural order.
+        # See https://github.com/blue-core-lod/bluecore-models/issues/94
+        if class_ is None:
+            resources = sorted(resources, key=lambda g: str(self._subject(g, class_)))
+
         for g in resources:
             uri = self._subject(g, class_)
             data = json.loads(g.serialize(format="json-ld"))
@@ -360,7 +369,12 @@ class BluecoreGraph:
         # bibframe:instanceOf assertions, and possible other inverse properties
         # that we might rely on?
 
-        for s, o in self.graph.subject_objects(BF.instanceOf):
+        # sort all the link iterations by URI so that, like _save, concurrent
+        # transactions acquire row locks in the same deterministic order.
+        for s, o in sorted(
+            self.graph.subject_objects(BF.instanceOf),
+            key=lambda pair: (str(pair[0]), str(pair[1])),
+        ):
             logger.info(f"linking {s} to {o}")
             instance = self._get_first(session, Instance, s)
             work = self._get_first(session, Work, o)
@@ -368,7 +382,10 @@ class BluecoreGraph:
             session.add(instance)
 
         # use bibframe:hasInstance to link works with instances
-        for s, o in self.graph.subject_objects(BF.hasInstance):
+        for s, o in sorted(
+            self.graph.subject_objects(BF.hasInstance),
+            key=lambda pair: (str(pair[0]), str(pair[1])),
+        ):
             logger.info(f"linking {s} to {o}")
             work = self._get_first(session, Work, s)
             instance = self._get_first(session, Instance, o)
@@ -384,10 +401,16 @@ class BluecoreGraph:
         self._delete_other_links(BF.Work, session)
         self._delete_other_links(BF.Instance, session)
 
-        work_graphs = self.works()
-        instance_graphs = self.instances()
+        work_graphs = sorted(
+            self.works(), key=lambda g: str(self._subject(g, BF.Work))
+        )
+        instance_graphs = sorted(
+            self.instances(), key=lambda g: str(self._subject(g, BF.Instance))
+        )
 
-        for other_graph in self.others():
+        for other_graph in sorted(
+            self.others(), key=lambda g: str(self._subject(g))
+        ):
             other_uri = self._subject(other_graph)
 
             # look at each Work graph and see if the Other Resource URI appears

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -145,8 +145,9 @@ class BluecoreGraph:
                         f"retrying graph save after {type(error.orig).__name__} "
                         f"(attempt {attempt} of {max_attempts})"
                     )
-                    continue
-                raise
+                else:
+                    logger.error(f"Exceeded {max_attempts} attempts with error {error}")
+                    raise
 
     def _infer(self) -> None:
         """
@@ -367,11 +368,9 @@ class BluecoreGraph:
                 resources = self.others()
                 sqla_class = OtherResource
 
-        # Write shared Other Resources in a deterministic, sorted-by-URI order.
-        # Concurrent transactions then acquire locks on these hot rows in the
-        # same order and serialize instead of deadlocking. Works and Instances
-        # are distinct per file (and have randomly minted URIs), so they are
-        # left in their natural order.
+        # Write Works, Instances, and shared Other Resources in a deterministic,
+        # sorted-by-URI order. Concurrent transactions then acquire locks on
+        # these hot rows in the same order and serialize instead of deadlocking.
         if class_ is None:
             resources = sorted(resources, key=lambda g: str(self._subject(g, class_)))
 

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -15,9 +15,6 @@ from bluecore_models.utils.graph import generate_entity_graph
 
 logger = logging.getLogger(__name__)
 
-# Postgres errors that mean "the transaction lost a race and can be safely
-# retried by re-running it from the start" (a graph save is self-contained).
-#
 # - DeadlockDetected / SerializationFailure: two writers locked shared rows in a
 #   conflicting way; Postgres aborted one of them.
 # - UniqueViolation: two writers both did get-or-create on the same brand-new
@@ -373,7 +370,6 @@ class BluecoreGraph:
         # same order and serialize instead of deadlocking. Works and Instances
         # are distinct per file (and have randomly minted URIs), so they are
         # left in their natural order.
-        # See https://github.com/blue-core-lod/bluecore-models/issues/94
         if class_ is None:
             resources = sorted(resources, key=lambda g: str(self._subject(g, class_)))
 
@@ -386,6 +382,8 @@ class BluecoreGraph:
             if obj:
                 obj.data = data
                 logger.info(f"updating {uri}")
+                # Sqlalchemy ORM already does a comparison between the retrieved object
+                # and new object and will only do an UPDATE if they are different
                 session.add(obj)
             else:
                 if sqla_class == OtherResource:

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -1,0 +1,316 @@
+import random
+import threading
+
+from psycopg2 import errors as pg_errors
+from rdflib import Graph
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from bluecore_models.bluecore_graph import BluecoreGraph, save_graph
+from bluecore_models.models import Instance, OtherResource, Work, BibframeOtherResources
+from bluecore_models.namespaces import BF
+from bluecore_models.utils.graph import load_jsonld
+
+
+jsonld_context = {
+    "@vocab": "http://id.loc.gov/ontologies/bibframe/",
+    "bflc": "http://id.loc.gov/ontologies/bflc/",
+    "mads": "http://www.loc.gov/mads/rdf/v1#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+}
+
+
+def _remove_fixtures(pg_session):
+    with pg_session() as session:
+        session.query(Instance).delete()
+        session.query(Work).delete()
+        session.query(BibframeOtherResources).delete()
+        session.query(OtherResource).delete()
+        session.commit()
+
+
+# ---------------------------------------------------------------------------
+# #1 Deterministic write ordering
+# ---------------------------------------------------------------------------
+def test_save_writes_other_resources_in_sorted_order(pg_session, monkeypatch):
+    """
+    Resources must be written in a stable (sorted-by-URI)
+    order so concurrent transactions acquire the hot Other Resource rows in the
+    same order and serialize instead of deadlocking.
+
+    We spy on Session.add and assert the Other Resources are added in
+    ascending-URI order. Currently they are added in arbitrary rdflib graph
+    order, so this fails.
+    """
+    _remove_fixtures(pg_session)
+
+    added_other_uris: list[str] = []
+    original_add = Session.add
+
+    def spy_add(self, obj, *args, **kwargs):
+        if isinstance(obj, OtherResource):
+            added_other_uris.append(obj.uri)
+        return original_add(self, obj, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "add", spy_add)
+
+    g = Graph()
+    g.parse("tests/23807141.ttl")
+    BluecoreGraph(g).save(pg_session)
+
+    assert len(added_other_uris) > 1, "sanity: multiple Other Resources were written"
+    assert added_other_uris == sorted(added_other_uris), (
+        "Other Resources should be written in deterministic sorted-by-URI order "
+        f"but were written as: {added_other_uris}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #5 Built-in serialization-failure retry
+# ---------------------------------------------------------------------------
+class _FlakySessionMaker:
+    """
+    Wraps a real sessionmaker. For the first `fail_times` sessions it produces,
+    the session's commit() raises an OperationalError wrapping a Postgres
+    DeadlockDetected (as SQLAlchemy surfaces a real deadlock). Subsequent
+    sessions commit normally.
+    """
+
+    def __init__(self, real_maker, fail_times=1):
+        self._real = real_maker
+        self._fail_times = fail_times
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        session = self._real(*args, **kwargs)
+        if self.calls <= self._fail_times:
+            def boom():
+                raise OperationalError(
+                    "UPDATE resource_base SET data=%(data)s::JSONB ...",
+                    {},
+                    pg_errors.DeadlockDetected("deadlock detected"),
+                )
+
+            session.commit = boom
+        return session
+
+
+def test_save_retries_on_deadlock(pg_session):
+    """
+    A DeadlockDetected/SerializationFailure should trigger an
+    automatic re-run of the whole per-graph save, since it is self-contained.
+
+    With a session whose first commit() raises a deadlock, save() should retry
+    on a fresh session and ultimately persist the Work. The current code has no
+    retry, so the OperationalError propagates and nothing is saved.
+    """
+    _remove_fixtures(pg_session)
+
+    flaky = _FlakySessionMaker(pg_session, fail_times=1)
+
+    g = Graph()
+    g.parse("tests/23807141.ttl")
+
+    # should NOT raise: the deadlock on the first attempt is retried
+    BluecoreGraph(g).save(flaky)
+
+    assert flaky.calls >= 2, "save() should have retried after the deadlock"
+
+    with pg_session() as session:
+        assert session.query(Work).count() == 2, "Works persisted after retry"
+
+
+# ---------------------------------------------------------------------------
+# #3 Atomic upsert instead of SELECT-then-INSERT (get-or-create race)
+# ---------------------------------------------------------------------------
+SHARED_OTHER_URI = "http://id.loc.gov/test/shared-authority"
+
+
+def _work_referencing_shared_other(work_uuid: str) -> Graph:
+    """A minimal Work graph that references the single shared Other Resource."""
+    return load_jsonld(
+        {
+            "@context": jsonld_context,
+            "@id": f"https://bcld.info/works/{work_uuid}",
+            "@type": BF.Work,
+            "title": {"@type": "Title", "mainTitle": "Gravity's Rainbow"},
+            "subject": {
+                "@id": SHARED_OTHER_URI,
+                "@type": "Topic",
+                "rdfs:label": "Shared Authority",
+            },
+        }
+    )
+
+
+def test_concurrent_first_time_create_of_same_uri(pg_session):
+    """
+    Replace the SELECT-then-INSERT get-or-create with an atomic upsert
+    (INSERT ... ON CONFLICT (uri) DO NOTHING/UPDATE).
+
+    Several concurrent writers each save a distinct Work that references the
+    SAME brand-new Other Resource. The current code does
+    `session.query(...).where(uri == ...).first()` then INSERTs on a miss, so
+    multiple writers miss and all INSERT the same uri -> a unique-constraint
+    IntegrityError.
+
+    A barrier lines the writers up so they all run their get-or-create before
+    any commits, which makes the race fire reliably against the current code.
+    With an atomic upsert, concurrent first-time creation must instead leave
+    exactly one row and raise nothing.
+    """
+    _remove_fixtures(pg_session)
+
+    writers = 5
+    rounds = 5
+    failures: list[tuple[str, str]] = []
+    failures_lock = threading.Lock()
+
+    for round_num in range(rounds):
+        # each round must be a genuine first-time create, so start empty
+        _remove_fixtures(pg_session)
+
+        barrier = threading.Barrier(writers)
+
+        def writer(idx: int) -> None:
+            work_uuid = f"{round_num:02d}{idx:02d}0000-0000-0000-0000-000000000000"
+            graph = _work_referencing_shared_other(work_uuid)
+            barrier.wait()  # all writers do get-or-create before anyone commits
+            try:
+                save_graph(pg_session, graph)
+            except Exception as exc:  # noqa: BLE001
+                orig = getattr(exc, "orig", None)
+                with failures_lock:
+                    failures.append((type(exc).__name__, type(orig).__name__))
+
+        threads = [
+            threading.Thread(target=writer, args=(idx,)) for idx in range(writers)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    assert failures == [], (
+        "concurrent first-time creation of the same uri should not raise, "
+        f"but {len(failures)} writer(s) failed: {failures[:5]}"
+    )
+
+    with pg_session() as session:
+        others = (
+            session.query(OtherResource)
+            .where(OtherResource.uri == SHARED_OTHER_URI)
+            .all()
+        )
+        assert len(others) == 1, (
+            "concurrent first-time creation should yield exactly one row, "
+            f"found {len(others)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: concurrent writers sharing authorities complete without deadlock
+# ---------------------------------------------------------------------------
+_NUM_SHARED_AUTHORITIES = 10
+_NUM_CONCURRENT_WRITERS = 5
+_NUM_ROUNDS = 5
+
+_SHARED_AUTHORITIES = [
+    f"http://id.loc.gov/test/auth/{i:02d}" for i in range(_NUM_SHARED_AUTHORITIES)
+]
+
+
+def _seed_authorities(pg_session) -> None:
+    """Pre-create the shared authority rows so every save UPDATEs (locks) them."""
+    with pg_session() as session:
+        for i, uri in enumerate(_SHARED_AUTHORITIES):
+            session.add(
+                OtherResource(
+                    uri=uri,
+                    data={"seed": i},
+                    type="other_resources",
+                    is_profile=False,
+                )
+            )
+        session.commit()
+
+
+def _work_referencing_all_authorities(work_uuid: str, order: list[str], salt: str) -> Graph:
+    """
+    A Work that references every shared authority (as a subject), in the given
+    order, with labels that differ from the seed so a real UPDATE is forced on
+    each hot row.
+    """
+    return load_jsonld(
+        {
+            "@context": jsonld_context,
+            "@id": f"https://bcld.info/works/{work_uuid}",
+            "@type": BF.Work,
+            "title": {"@type": "Title", "mainTitle": f"Work {salt}"},
+            "subject": [
+                {"@id": uri, "@type": "Topic", "rdfs:label": f"label-{uri}-{salt}"}
+                for uri in order
+            ],
+        }
+    )
+
+
+def test_concurrent_writers_sharing_authorities_no_deadlock(pg_session):
+    """
+    Two or more concurrent save_graph() writers loading records that 
+    share authorities must complete without DeadlockDetected.
+
+    Each round launches several writers concurrently. Every writer saves a
+    distinct Work that references the SAME set of pre-seeded shared authorities,
+    but in a different (shuffled) order and with distinct label data so each
+    save takes a write lock on every hot row. Because the current code locks
+    those rows in arbitrary graph order, concurrent writers acquire them in
+    conflicting orders and Postgres raises DeadlockDetected (verified to occur
+    in every round against the current implementation).
+
+    """
+    _remove_fixtures(pg_session)
+    _seed_authorities(pg_session)
+
+    failures: list[tuple[str, str]] = []
+    failures_lock = threading.Lock()
+
+    for round_num in range(_NUM_ROUNDS):
+
+        def writer(idx: int) -> None:
+            order = _SHARED_AUTHORITIES[:]
+            random.Random(round_num * 1000 + idx).shuffle(order)
+            work_uuid = f"{round_num:02d}{idx:02d}0000-0000-0000-0000-000000000000"
+            graph = _work_referencing_all_authorities(
+                work_uuid, order, salt=f"{round_num}-{idx}"
+            )
+            try:
+                save_graph(pg_session, graph)
+            except Exception as exc:  # noqa: BLE001 - record anything that surfaces
+                orig = getattr(exc, "orig", None)
+                with failures_lock:
+                    failures.append((type(exc).__name__, type(orig).__name__))
+
+        threads = [
+            threading.Thread(target=writer, args=(idx,))
+            for idx in range(_NUM_CONCURRENT_WRITERS)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    assert failures == [], (
+        "concurrent writers sharing authorities should complete without "
+        f"DeadlockDetected, but {len(failures)} writer(s) failed: {failures[:5]}"
+    )
+
+    # sanity: the shared authorities still exist exactly once each
+    with pg_session() as session:
+        assert (
+            session.query(OtherResource)
+            .where(OtherResource.uri.in_(_SHARED_AUTHORITIES))
+            .count()
+            == _NUM_SHARED_AUTHORITIES
+        )

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -84,6 +84,7 @@ class _FlakySessionMaker:
         self.calls += 1
         session = self._real(*args, **kwargs)
         if self.calls <= self._fail_times:
+
             def boom():
                 raise OperationalError(
                     "UPDATE resource_base SET data=%(data)s::JSONB ...",
@@ -233,7 +234,9 @@ def _seed_authorities(pg_session) -> None:
         session.commit()
 
 
-def _work_referencing_all_authorities(work_uuid: str, order: list[str], salt: str) -> Graph:
+def _work_referencing_all_authorities(
+    work_uuid: str, order: list[str], salt: str
+) -> Graph:
     """
     A Work that references every shared authority (as a subject), in the given
     order, with labels that differ from the seed so a real UPDATE is forced on
@@ -255,7 +258,7 @@ def _work_referencing_all_authorities(work_uuid: str, order: list[str], salt: st
 
 def test_concurrent_writers_sharing_authorities_no_deadlock(pg_session):
     """
-    Two or more concurrent save_graph() writers loading records that 
+    Two or more concurrent save_graph() writers loading records that
     share authorities must complete without DeadlockDetected.
 
     Each round launches several writers concurrently. Every writer saves a

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -127,8 +127,8 @@ def test_save_retries_on_deadlock(pg_session):
 SHARED_OTHER_URI = "http://id.loc.gov/test/shared-authority"
 
 
-def _work_referencing_shared_other(work_uuid: str) -> Graph:
-    """A minimal Work graph that references the single shared Other Resource."""
+def _work_referencing_shared_other(work_uuid: str, other_uri: str) -> Graph:
+    """A minimal Work graph that references the given shared Other Resource."""
     return load_jsonld(
         {
             "@context": jsonld_context,
@@ -136,7 +136,7 @@ def _work_referencing_shared_other(work_uuid: str) -> Graph:
             "@type": BF.Work,
             "title": {"@type": "Title", "mainTitle": "Gravity's Rainbow"},
             "subject": {
-                "@id": SHARED_OTHER_URI,
+                "@id": other_uri,
                 "@type": "Topic",
                 "rdfs:label": "Shared Authority",
             },
@@ -146,19 +146,20 @@ def _work_referencing_shared_other(work_uuid: str) -> Graph:
 
 def test_concurrent_first_time_create_of_same_uri(pg_session):
     """
-    Replace the SELECT-then-INSERT get-or-create with an atomic upsert
-    (INSERT ... ON CONFLICT (uri) DO NOTHING/UPDATE).
+    Acceptance criterion #3: concurrent first-time creation of the same Other
+    Resource uri must not raise a unique-constraint error.
 
     Several concurrent writers each save a distinct Work that references the
     SAME brand-new Other Resource. The current code does
     `session.query(...).where(uri == ...).first()` then INSERTs on a miss, so
     multiple writers miss and all INSERT the same uri -> a unique-constraint
-    IntegrityError.
+    IntegrityError. A barrier lines the writers up so they all run their
+    get-or-create before any commits, which makes the race fire reliably
+    against the current code.
 
-    A barrier lines the writers up so they all run their get-or-create before
-    any commits, which makes the race fire reliably against the current code.
-    With an atomic upsert, concurrent first-time creation must instead leave
-    exactly one row and raise nothing.
+    Each round uses a fresh, never-before-seen authority uri so that every
+    round is a genuine *first-time* creation (the acceptance scenario), run
+    several times to make the race reliably reproducible.
     """
     _remove_fixtures(pg_session)
 
@@ -168,14 +169,13 @@ def test_concurrent_first_time_create_of_same_uri(pg_session):
     failures_lock = threading.Lock()
 
     for round_num in range(rounds):
-        # each round must be a genuine first-time create, so start empty
-        _remove_fixtures(pg_session)
+        other_uri = f"{SHARED_OTHER_URI}/{round_num}"
 
         barrier = threading.Barrier(writers)
 
-        def writer(idx: int) -> None:
+        def writer(idx: int, other_uri: str = other_uri) -> None:
             work_uuid = f"{round_num:02d}{idx:02d}0000-0000-0000-0000-000000000000"
-            graph = _work_referencing_shared_other(work_uuid)
+            graph = _work_referencing_shared_other(work_uuid, other_uri)
             barrier.wait()  # all writers do get-or-create before anyone commits
             try:
                 save_graph(pg_session, graph)
@@ -197,16 +197,18 @@ def test_concurrent_first_time_create_of_same_uri(pg_session):
         f"but {len(failures)} writer(s) failed: {failures[:5]}"
     )
 
+    # every round's authority should have been created exactly once
     with pg_session() as session:
-        others = (
-            session.query(OtherResource)
-            .where(OtherResource.uri == SHARED_OTHER_URI)
-            .all()
-        )
-        assert len(others) == 1, (
-            "concurrent first-time creation should yield exactly one row, "
-            f"found {len(others)}"
-        )
+        for round_num in range(rounds):
+            others = (
+                session.query(OtherResource)
+                .where(OtherResource.uri == f"{SHARED_OTHER_URI}/{round_num}")
+                .all()
+            )
+            assert len(others) == 1, (
+                "concurrent first-time creation should yield exactly one row for "
+                f"{SHARED_OTHER_URI}/{round_num}, found {len(others)}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -30,7 +30,7 @@ def _remove_fixtures(pg_session):
 
 
 # ---------------------------------------------------------------------------
-# #1 Deterministic write ordering
+# Deterministic write ordering
 # ---------------------------------------------------------------------------
 def test_save_writes_other_resources_in_sorted_order(pg_session, monkeypatch):
     """
@@ -39,8 +39,7 @@ def test_save_writes_other_resources_in_sorted_order(pg_session, monkeypatch):
     same order and serialize instead of deadlocking.
 
     We spy on Session.add and assert the Other Resources are added in
-    ascending-URI order. Currently they are added in arbitrary rdflib graph
-    order, so this fails.
+    ascending-URI order.
     """
     _remove_fixtures(pg_session)
 
@@ -66,7 +65,7 @@ def test_save_writes_other_resources_in_sorted_order(pg_session, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# #5 Built-in serialization-failure retry
+# Built-in serialization-failure retry
 # ---------------------------------------------------------------------------
 class _FlakySessionMaker:
     """
@@ -102,8 +101,7 @@ def test_save_retries_on_deadlock(pg_session):
     automatic re-run of the whole per-graph save, since it is self-contained.
 
     With a session whose first commit() raises a deadlock, save() should retry
-    on a fresh session and ultimately persist the Work. The current code has no
-    retry, so the OperationalError propagates and nothing is saved.
+    on a fresh session and ultimately persist the Work.
     """
     _remove_fixtures(pg_session)
 
@@ -122,7 +120,7 @@ def test_save_retries_on_deadlock(pg_session):
 
 
 # ---------------------------------------------------------------------------
-# #3 Atomic upsert instead of SELECT-then-INSERT (get-or-create race)
+# Atomic upsert instead of SELECT-then-INSERT (get-or-create race)
 # ---------------------------------------------------------------------------
 SHARED_OTHER_URI = "http://id.loc.gov/test/shared-authority"
 
@@ -146,9 +144,6 @@ def _work_referencing_shared_other(work_uuid: str, other_uri: str) -> Graph:
 
 def test_concurrent_first_time_create_of_same_uri(pg_session):
     """
-    Acceptance criterion #3: concurrent first-time creation of the same Other
-    Resource uri must not raise a unique-constraint error.
-
     Several concurrent writers each save a distinct Work that references the
     SAME brand-new Other Resource. The current code does
     `session.query(...).where(uri == ...).first()` then INSERTs on a miss, so
@@ -266,11 +261,7 @@ def test_concurrent_writers_sharing_authorities_no_deadlock(pg_session):
     Each round launches several writers concurrently. Every writer saves a
     distinct Work that references the SAME set of pre-seeded shared authorities,
     but in a different (shuffled) order and with distinct label data so each
-    save takes a write lock on every hot row. Because the current code locks
-    those rows in arbitrary graph order, concurrent writers acquire them in
-    conflicting orders and Postgres raises DeadlockDetected (verified to occur
-    in every round against the current implementation).
-
+    save takes a write lock on every hot row.
     """
     _remove_fixtures(pg_session)
     _seed_authorities(pg_session)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -86,6 +86,7 @@ dependencies = [
     { name = "pyld" },
     { name = "pymilvus", extra = ["milvus-lite", "model"] },
     { name = "rdflib" },
+    { name = "tenacity" },
     { name = "transformers" },
 ]
 
@@ -107,6 +108,7 @@ requires-dist = [
     { name = "pyld", specifier = ">=2.0.4" },
     { name = "pymilvus", extras = ["model", "milvus-lite"] },
     { name = "rdflib", specifier = ">=7.1.3" },
+    { name = "tenacity", specifier = ">=9.1.4" },
     { name = "transformers", specifier = "==4.57.5" },
 ]
 
@@ -226,8 +228,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -282,7 +284,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -290,7 +294,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -298,7 +304,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -306,14 +314,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -321,7 +333,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -658,10 +672,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [
@@ -1608,6 +1622,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
     { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
     { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When running the `archived_files_load` DAG in the new on-prem environment, was seeing multiple errors in the logs similar to these errors:

```bash
[2026-06-12, 13:29:35] INFO - ERROR:__main__:Error (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely): source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - (psycopg2.errors.DeadlockDetected) deadlock detected: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - DETAIL:  Process 1141868 waits for ShareLock on transaction 201877; blocked by process 1141894.: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - Process 1141894 waits for ShareLock on transaction 201863; blocked by process 1141868.: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - HINT:  See server log for query details.: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - CONTEXT:  while updating tuple (74,1) in relation "resource_base": source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - : source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - [SQL: UPDATE resource_base SET data=%(data)s::JSONB, updated_at=%(updated_at)s WHERE resource_base.id = %(resource_base_id)s]: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - [parameters: {'data': '{"@context": {"@vocab": "http://id.loc.gov/ontologies/bibframe/", "bflc": "http://id.loc.gov/ontologies/bflc/", "mads": "http://www.loc.gov/mads/rdf/ ... (80 characters truncated) ... v/authorities/subjects", "@type": ["mads:MADSScheme", "Source"], "rdfs:label": {"@language": "en", "@value": "Library of Congress Subject Headings"}}', 'updated_at': datetime.datetime(2026, 6, 12, 19, 29, 34, 536760, tzinfo=datetime.timezone.utc), 'resource_base_id': 82}]: source="airflow.utils.process_utils"
[2026-06-12, 13:29:35] INFO - (Background on this error at: https://sqlalche.me/e/20/e3q8): source="airflow.utils.process_utils"
```
With Claude Code assistance, the problems root is that when multiple OtherResources that share the same URI are saved in different transactions, the first locks the row and the second or subsequent transactions tried to update the row and a Deadlock occurs. This code provides a couple of ways to address these deadlocks, the first is to sort the URIs for the Other Resources which makes the URIs order more deterministic and the second is to make the entire save_graph to repeat if a Deadlock or related error occurs for up to maximum attempts of 3.