### PR TITLE
Bump pyproject version for tagged release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.13.0"
+version = "0.14.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump version to 0.14.0 to publish tagged release to PyPI.