### PR TITLE
Remove unused code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.15.1"
+version = "0.16.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/utils/graph.py
+++ b/src/bluecore_models/utils/graph.py
@@ -1,36 +1,12 @@
 """Utility functions for working with RDF graphs."""
 
-import json
 import logging
 from typing import Dict
-from uuid import uuid4
 
 from pyld import jsonld
 from rdflib import Graph, URIRef, RDF, Node, DCTERMS, BNode
-from rdflib.plugins.sparql import prepareUpdate
-from rdflib.query import ResultRow
 
 from bluecore_models.namespaces import BF, BFLC, LCLOCAL, MADS
-
-UPDATE_SPARQL = prepareUpdate("""
-DELETE {
-  ?old_subject ?p ?o .
-  ?s ?pp $old_subject
-}
-INSERT {
-  ?bluecore_uri ?p ?o .
-  ?s ?pp ?bluecore_uri .
-}
-WHERE {
-  {
-    ?old_subject ?p ?o .
-  }
-  UNION {
-    ?s ?pp ?old_subject .
-  }
-}
-""")
-
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +48,6 @@ def _check_for_namespace(node: Node) -> bool:
     return node in LCLOCAL or node in DCTERMS  # type: ignore
 
 
-def _exclude_uri_from_other_resources(uri: Node) -> bool:
-    """Checks if uri is in the BF, MADS, or RDF namespaces"""
-    return uri in BF or uri in MADS or uri in RDF  # type: ignore
-
-
 def _expand_bnode(graph: Graph, entity_graph: Graph, bnode: BNode) -> None:
     """Expand a blank node in the entity graph."""
 
@@ -93,67 +64,6 @@ def _expand_bnode(graph: Graph, entity_graph: Graph, bnode: BNode) -> None:
             _expand_bnode(graph, entity_graph, obj)
 
 
-def _is_work_or_instance(uri: Node, graph: Graph) -> bool:
-    """Checks if uri is a BIBFRAME Work or Instance"""
-    for class_ in graph.objects(subject=uri, predicate=RDF.type):
-        # In the future we may want to include Work and Instances subclasses
-        # maybe through inference
-        if class_ == BF.Work or class_ == BF.Instance:
-            return True
-    return False
-
-
-def _mint_uri(env_root: str, type_of: str) -> tuple:
-    """
-    Mints a Work or Instance URI based on the environment.
-    """
-    uuid = uuid4()
-    if not type_of.endswith("s"):
-        type_of = f"{type_of}s"
-    if env_root.endswith("/"):
-        env_root = env_root[0:-1]
-    return f"{env_root}/{type_of}/{uuid}", str(uuid)
-
-
-def _update_graph(**kwargs) -> Graph:
-    """
-    Updates graph using a Blue Core URI subject. If incoming subject is
-    an URI, create a new derivedFrom assertion.
-    """
-    graph: Graph = kwargs["graph"]
-    bluecore_uri: str = kwargs["bluecore_uri"]
-    bluecore_type: str = kwargs["bluecore_type"]
-
-    match bluecore_type.lower():
-        case "works" | "work":
-            object_uri = BF.Work
-
-        case "instances" | "instance":
-            object_uri = BF.Instance
-
-        case "hubs" | "hub":
-            object_uri = BF.Hub
-
-        case _:
-            raise ValueError(f"Unsupported bluecore_type: {bluecore_type}")
-
-    external_subject = graph.value(predicate=RDF.type, object=object_uri)
-    if external_subject is None:
-        raise ValueError(f"Cannot find external subject with a type of {object_uri}")
-
-    graph.update(
-        UPDATE_SPARQL,
-        initBindings={
-            "old_subject": external_subject,  # type: ignore
-            "bluecore_uri": URIRef(bluecore_uri),  # type: ignore
-        },
-    )
-
-    if not isinstance(external_subject, BNode):
-        graph.add((URIRef(bluecore_uri), BF.derivedFrom, external_subject))
-    return graph
-
-
 def generate_entity_graph(graph: Graph, entity: Node) -> Graph:
     """Generate an entity graph from a larger RDF graph."""
     entity_graph = init_graph()
@@ -164,38 +74,6 @@ def generate_entity_graph(graph: Graph, entity: Node) -> Graph:
         if isinstance(obj, BNode):
             _expand_bnode(graph, entity_graph, obj)
     return entity_graph
-
-
-def generate_other_resources(record_graph: Graph, entity_graph: Graph) -> list:
-    """
-    Takes a Record Graph and Entity Graph and returns a list of dictionaries
-    where each dict contains the sub-graphs and URIs that referenced in the
-    entity graph and present in the record graph.
-    """
-    other_resources = []
-    logger.info(f"Size of entity graph {len(entity_graph)}")
-    for row in entity_graph.query("""
-      SELECT DISTINCT ?object
-      WHERE {
-        ?subject ?predicate ?object .
-        FILTER(isIRI(?object))
-      }
-    """):
-        assert isinstance(row, ResultRow)
-        uri = row[0]
-        if _exclude_uri_from_other_resources(uri) or _is_work_or_instance(
-            uri, record_graph
-        ):
-            continue
-        other_resource_graph = generate_entity_graph(record_graph, uri)
-        if len(other_resource_graph) > 0:
-            other_resources.append(
-                {
-                    "uri": str(uri),
-                    "graph": other_resource_graph.serialize(format="json-ld"),
-                }
-            )
-    return other_resources
 
 
 def get_bf_classes(rdf_data: list | dict, uri: str) -> list:
@@ -226,26 +104,3 @@ def frame_jsonld(bluecore_uri: str, jsonld_data: list | dict) -> dict:
     )
 
     return doc
-
-
-def handle_external_subject(**kwargs) -> dict:
-    """
-    Handles external subject terms in new Blue Core descriptions
-    """
-    raw_jsonld = kwargs["data"]
-    env_root = kwargs["bluecore_base_url"]
-    bluecore_type = kwargs["type"]
-
-    graph = init_graph()
-    graph.parse(data=raw_jsonld, format="json-ld")
-
-    bluecore_uri, uuid = _mint_uri(env_root, bluecore_type)
-    modified_graph = _update_graph(
-        graph=graph, bluecore_uri=bluecore_uri, bluecore_type=bluecore_type
-    )
-
-    return {
-        "uri": bluecore_uri,
-        "data": json.loads(modified_graph.serialize(format="json-ld")),
-        "uuid": uuid,
-    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,12 +9,9 @@ from bluecore_models.utils.graph import (
     BFLC,
     MADS,
     generate_entity_graph,
-    generate_other_resources,
-    handle_external_subject,
     init_graph,
     load_jsonld,
     _expand_bnode,
-    _is_work_or_instance,
 )
 
 
@@ -54,74 +51,6 @@ def test_generate_entity_graph():
         subject=work_uri, predicate=rdflib.DCTERMS.isPartOf
     )
     assert work_dcterm_part_of is None
-
-
-def test_generate_other_resources():
-    loc_graph = load_jsonld(json.load(Path("tests/23807141.jsonld").open()))
-    work_uri = URIRef("http://id.loc.gov/resources/works/23807141")
-    work_graph = generate_entity_graph(loc_graph, work_uri)
-    other_work_resources = generate_other_resources(loc_graph, work_graph)
-    assert len(other_work_resources) == 25
-    sorted_other_work_resources = sorted(other_work_resources, key=lambda x: x["uri"])
-    assert sorted_other_work_resources[0]["uri"].startswith(
-        "http://id.loc.gov/authorities/subjects"
-    )
-    assert sorted_other_work_resources[-1]["uri"].startswith(
-        "http://id.loc.gov/vocabulary/relators/aut"
-    )
-
-    instance_uri = URIRef("http://id.loc.gov/resources/instances/23807141")
-    instance_graph = generate_entity_graph(loc_graph, instance_uri)
-    other_instance_resources = generate_other_resources(loc_graph, instance_graph)
-    assert len(other_instance_resources) == 14
-    sorted_other_instance_resources = sorted(
-        other_instance_resources, key=lambda x: x["uri"]
-    )
-    assert sorted_other_instance_resources[0]["uri"].startswith(
-        "http://id.loc.gov/vocabulary/carriers/cr"
-    )
-    assert sorted_other_instance_resources[-1]["uri"].startswith(
-        "http://id.loc.gov/vocabulary/organizations/dlcmrc"
-    )
-
-
-def test_handle_external_bnode_subject(mocker):
-    mocker.patch(
-        "bluecore_models.utils.graph.uuid4",
-        return_value="ac35fae6-3727-11f0-a057-5a0f9a6cb774",
-    )
-
-    work_uri = URIRef("https://bcld.info/works/ac35fae6-3727-11f0-a057-5a0f9a6cb774")
-    graph = init_graph()
-    subject = rdflib.BNode()
-    graph.add((subject, rdflib.RDF.type, BF.Work))
-    title_bnode = rdflib.BNode()
-    graph.add((subject, BF.title, title_bnode))
-    graph.add((title_bnode, BF.mainTitle, Literal("A Testing Work")))
-
-    result = handle_external_subject(
-        bluecore_base_url="https://bcld.info/",
-        data=graph.serialize(format="json-ld"),
-        type="works",
-    )
-
-    assert result["uri"] == str(work_uri)
-    bluecore_graph = load_jsonld(result["data"])
-
-    bluecore_title = bluecore_graph.value(subject=work_uri, predicate=BF.title)
-    assert (
-        str(bluecore_graph.value(subject=bluecore_title, predicate=BF.mainTitle))
-        == "A Testing Work"
-    )
-
-
-def test_is_work_or_instance():
-    loc_graph = init_graph()
-    work_uri = URIRef("http://id.loc.gov/resources/works/23807141")
-    # Adds a fake class to work
-    loc_graph.add((work_uri, rdflib.RDF.type, MADS.Resource))
-    loc_graph.add((work_uri, rdflib.RDF.type, BF.Work))
-    assert _is_work_or_instance(work_uri, loc_graph)
 
 
 def test_bnode_expansion():


### PR DESCRIPTION
Now that we are using BluecoreGraph to persist RDF to the database we can remove some code that is no longer used.

I tested by installing this branch in bluecore_api and bluecore-workflows to see if the unit tests passed. They did!

At some point it might be possible to move some of the remaining code into BluecoreGraph. 

Closes #104
