### PR TITLE
Profile resource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.18.1"
+version = "0.19.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 from psycopg2 import errors as psycopg2_errors
 from rdflib import BNode, Graph, IdentifiedNode, Literal, Namespace, Node, URIRef, XSD
-from rdflib.plugins import sparql
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm.session import sessionmaker, Session
@@ -20,7 +19,7 @@ from bluecore_models.models import (
     BibframeOtherResources,
 )
 from bluecore_models.models.version import CURRENT_USER_ID
-from bluecore_models.utils.graph import generate_entity_graph
+from bluecore_models.utils.graph import generate_entity_graph, replace_uri
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +179,14 @@ class BluecoreGraph:
                         self._save(
                             None, session
                         )  # there is no catchall URI for Other Resources
+
+                        # flush so the just-added resources have ids and are
+                        # visible to _link's uri lookups. Required because the
+                        # session may have autoflush disabled (as the
+                        # bluecore_api session does), in which case _link's
+                        # queries would otherwise not see them and would build
+                        # link rows with null foreign keys.
+                        session.flush()
 
                         # link all the works, instances and other resources together in the db
                         self._link(session)
@@ -471,10 +478,7 @@ class BluecoreGraph:
         A bibframe:derivedFrom assertion is added to record the relationship
         if the derived_from is URIRef.
         """
-        self.graph.update(
-            UPDATE_SPARQL,
-            initBindings={"old_subject": derived_from, "bluecore_uri": bluecore_uri},
-        )
+        replace_uri(self.graph, derived_from, bluecore_uri)
         # only add derivedFrom assertions for URIs
         if isinstance(derived_from, URIRef):
             self._generate_admin_metadata(bluecore_uri, derived_from)
@@ -669,23 +673,3 @@ class BluecoreGraph:
             raise Exception(f"Unable to find in db: uri={uri}")
 
         return obj
-
-
-UPDATE_SPARQL = sparql.prepareUpdate("""
-DELETE {
-  ?old_subject ?p ?o .
-  ?s ?pp $old_subject
-}
-INSERT {
-  ?bluecore_uri ?p ?o .
-  ?s ?pp ?bluecore_uri .
-}
-WHERE {
-  {
-    ?old_subject ?p ?o .
-  }
-  UNION {
-    ?s ?pp ?old_subject .
-  }
-}
-""")

--- a/src/bluecore_models/migrations/versions/20260626_add_profiles_table.py
+++ b/src/bluecore_models/migrations/versions/20260626_add_profiles_table.py
@@ -1,0 +1,96 @@
+"""Add profiles table and migrate is_profile OtherResources into it
+
+Profiles (formerly OtherResources with is_profile=True) become their own
+polymorphic ResourceBase subclass. Existing profile rows are re-tagged as
+'profiles', moved out of other_resources, and given a uuid + a minted
+``.../profiles/{uuid}`` uri so they are addressed like Works/Instances/Hubs.
+Finally the now-unused other_resources.is_profile column is dropped.
+
+Revision ID: 20260626
+Revises: 20260625
+Create Date: 2026-06-26
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260626"
+down_revision: str = "20260625"
+branch_labels = None
+depends_on = None
+
+
+def _base_url() -> str:
+    return os.environ.get("BLUECORE_URL", "https://bcld.info/").rstrip("/")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "profiles",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["id"], ["resource_base.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Move the is_profile OtherResources into the profiles table.
+    op.execute(
+        """
+        INSERT INTO profiles (id)
+        SELECT id FROM other_resources WHERE is_profile = true
+        """
+    )
+    op.execute(
+        """
+        UPDATE resource_base SET type = 'profiles'
+        WHERE id IN (SELECT id FROM other_resources WHERE is_profile = true)
+        """
+    )
+    op.execute("DELETE FROM other_resources WHERE is_profile = true")
+
+    # Give every profile a uuid and a minted bcld uri so they are uniform with
+    # Works/Instances/Hubs (replacing any external Sinopia profile uri).
+    op.execute(
+        "UPDATE resource_base SET uuid = gen_random_uuid() "
+        "WHERE type = 'profiles' AND uuid IS NULL"
+    )
+    op.execute(
+        f"UPDATE resource_base SET uri = '{_base_url()}/profiles/' || uuid::text "
+        "WHERE type = 'profiles'"
+    )
+
+    op.drop_column("other_resources", "is_profile")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "other_resources",
+        sa.Column(
+            "is_profile",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+    # Return profiles to other_resources as is_profile rows.
+    op.execute(
+        """
+        INSERT INTO other_resources (id, is_profile)
+        SELECT id, true FROM profiles
+        """
+    )
+    op.execute(
+        """
+        UPDATE resource_base SET type = 'other_resources'
+        WHERE id IN (SELECT id FROM profiles)
+        """
+    )
+    op.drop_table("profiles")
+
+    # The original (Sinopia) uris overwritten in upgrade() cannot be recovered;
+    # downgraded rows keep their minted .../profiles/{uuid} uri.
+
+    op.alter_column("other_resources", "is_profile", server_default=None)

--- a/src/bluecore_models/models/__init__.py
+++ b/src/bluecore_models/models/__init__.py
@@ -12,3 +12,4 @@ from bluecore_models.models.other_resource import (
     OtherResource as OtherResource,
     BibframeOtherResources as BibframeOtherResources,
 )
+from bluecore_models.models.profile import Profile as Profile

--- a/src/bluecore_models/models/other_resource.py
+++ b/src/bluecore_models/models/other_resource.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, ForeignKey
+from sqlalchemy import DateTime, Integer, ForeignKey
 
 from sqlalchemy.orm import (
     mapped_column,
@@ -21,7 +21,6 @@ class OtherResource(ResourceBase):
     id: Mapped[int] = mapped_column(
         Integer, ForeignKey("resource_base.id"), primary_key=True
     )
-    is_profile: Mapped[bool] = mapped_column(Boolean, default=False)
 
     __mapper_args__ = {
         "polymorphic_identity": "other_resources",

--- a/src/bluecore_models/models/profile.py
+++ b/src/bluecore_models/models/profile.py
@@ -1,0 +1,41 @@
+from sqlalchemy import ForeignKey, Integer, event
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bluecore_models.models.resource import ResourceBase
+from bluecore_models.utils.db import add_version
+
+
+class Profile(ResourceBase):
+    """
+    Stores resource profiles (e.g. Sinopia profiles) used to drive editing.
+
+    A Profile is a first-class Bluecore resource: like Works, Instances and
+    Hubs it is assigned a ``uuid`` and a minted ``uri`` (``.../profiles/{uuid}``).
+    Unlike them, its ``data`` is not framed when persisted because Sinopia
+    Editor requires it to be in a particular shape (the set_jsonld handler
+    in resource.py skips Profiles).
+    """
+
+    __tablename__ = "profiles"
+    id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("resource_base.id"), primary_key=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "profiles",
+    }
+
+    def __repr__(self):
+        return f"<Profile {self.uri or self.id}>"
+
+
+@event.listens_for(Profile, "after_insert")
+def create_version(mapper, connection, target):
+    """Record a Version when a Profile is created."""
+    add_version(connection, target)
+
+
+@event.listens_for(Profile, "after_update")
+def update_version(mapper, connection, target):
+    """Record a Version when a Profile is modified."""
+    add_version(connection, target)

--- a/src/bluecore_models/models/resource.py
+++ b/src/bluecore_models/models/resource.py
@@ -90,9 +90,6 @@ def set_jsonld(target, value, oldvalue, initiator) -> dict[str, Any] | None:
     to the database. Note the ordering of properties used in constructors
     matters, since target.uri must be set on the object prior to setting data.
 
-    Also, if it is an OtherResource that has is_profile set to True, the data
-    will not be framed, since it is not JSON-LD and has no uri.
-
     So this will work:
 
         >>> w = Work(uri="https://example.com", data={ ... })
@@ -101,8 +98,16 @@ def set_jsonld(target, value, oldvalue, initiator) -> dict[str, Any] | None:
 
         >>> w = Work(data={...}, uri="https://example.com")
 
+    Also, if the target is a Profile the data will not be framed, since
+    sinopia-editor expects it to be in a particular shape. Maybe someday
+    we can frame it?!
     """
-    if hasattr(target, "is_profile") and target.is_profile is True:
+    # Local import to avoid a circular import: profile.py imports ResourceBase
+    # from this module. The data setter only fires on a constructed instance, by
+    # which point all model modules are loaded.
+    from bluecore_models.models.profile import Profile
+
+    if isinstance(target, Profile):
         return value
     elif target.uri is None and value is not None:
         raise ValueError(

--- a/src/bluecore_models/utils/graph.py
+++ b/src/bluecore_models/utils/graph.py
@@ -4,11 +4,33 @@ import logging
 from typing import Any
 
 from pyld import jsonld
-from rdflib import BNode, DCTERMS, Graph, Node, RDF, URIRef
+from rdflib import BNode, DCTERMS, Graph, IdentifiedNode, Node, RDF, URIRef
+from rdflib.plugins import sparql
 
 from bluecore_models.namespaces import BF, BFLC, LCLOCAL, MADS
 
 logger = logging.getLogger(__name__)
+
+# Rewrites every occurrence of ?old_uri to ?new_uri in a graph, in both subject
+# position (?old_uri ?p ?o) and object position (?s ?pp ?old_uri).
+_REPLACE_URI_SPARQL = sparql.prepareUpdate("""
+DELETE {
+  ?old_uri ?p ?o .
+  ?s ?pp ?old_uri .
+}
+INSERT {
+  ?new_uri ?p ?o .
+  ?s ?pp ?new_uri .
+}
+WHERE {
+  {
+    ?old_uri ?p ?o .
+  }
+  UNION {
+    ?s ?pp ?old_uri .
+  }
+}
+""")
 
 CONTEXT: dict[str, Any] = {
     "@vocab": "http://id.loc.gov/ontologies/bibframe/",
@@ -54,6 +76,18 @@ def load_jsonld(jsonld_data: list[Any] | dict[str, Any]) -> Graph:
             )
 
     return graph
+
+
+def replace_uri(graph: Graph, old_uri: IdentifiedNode, new_uri: URIRef) -> None:
+    """
+    Rewrite every occurrence of old_uri to new_uri in the graph, in both subject
+    position (old_uri ?p ?o) and object position (?s ?pp old_uri). old_uri may be
+    a blank node or a URIRef; new_uri is always a real (minted) URIRef.
+    """
+    graph.update(
+        _REPLACE_URI_SPARQL,
+        initBindings={"old_uri": old_uri, "new_uri": new_uri},
+    )
 
 
 def _check_for_namespace(node: Node) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,6 @@ def create_test_rows():
                 "http://www.w3.org/2000/01/rdf-schema#label": "test",
             },
             type="other_resources",
-            is_profile=False,
         ),
         BibframeOtherResources(
             other_resource_id=3,

--- a/tests/test_bluecore_graph.py
+++ b/tests/test_bluecore_graph.py
@@ -2,7 +2,8 @@ import json
 import uuid
 
 import pytest
-from rdflib import Graph, URIRef
+from rdflib import BNode, Graph, Literal, URIRef
+from sqlalchemy.orm import sessionmaker
 
 from bluecore_models import bluecore_graph
 from bluecore_models.bluecore_graph import BluecoreGraph, save_graph
@@ -192,6 +193,53 @@ def test_non_bluecore_work(pg_session, monkeypatch, mocker):
     save_graph(pg_session, load_jsonld(jsonld_object))
 
     assert uuid_spy.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "bf_class, sqla_class, collection",
+    [
+        (BF.Work, Work, "works"),
+        (BF.Instance, Instance, "instances"),
+        (BF.Hub, Hub, "hubs"),
+    ],
+)
+def test_blank_node_resource(
+    pg_session, monkeypatch, mocker, bf_class, sqla_class, collection
+):
+    """
+    A graph whose subject is a blank node (i.e. has no URI yet, as when a
+    brand-new resource is created in an editor) should be persisted with a freshly
+    minted bluecore URI and NO derivedFrom assertion, since there is no original
+    URI to derive from.
+    """
+    minted_uuid = "7dbb7674-7373-473f-9014-b9a993a2dd03"
+    monkeypatch.setattr(bluecore_graph, "uuid4", lambda *args, **kwargs: minted_uuid)
+
+    uuid_spy = mocker.spy(bluecore_graph, "uuid4")
+
+    graph = Graph()
+    resource = BNode()
+    title = BNode()
+    graph.add((resource, RDF.type, bf_class))
+    graph.add((resource, BF.title, title))
+    graph.add((title, RDF.type, BF.Title))
+    graph.add((title, BF.mainTitle, Literal("Gravity's Rainbow")))
+
+    assert uuid_spy.call_count == 0
+    save_graph(pg_session, graph)
+    assert uuid_spy.call_count == 1
+
+    with pg_session() as session:
+        db_resource = (
+            session.query(sqla_class)
+            .where(sqla_class.uri == f"https://bcld.info/{collection}/{minted_uuid}")
+            .first()
+        )
+        assert db_resource is not None
+        assert db_resource.uuid == uuid.UUID(minted_uuid)
+        assert db_resource.data["title"]["mainTitle"] == "Gravity's Rainbow"
+        # no derivedFrom should be recorded for a brand-new (blank node) resource
+        assert _derived_from_ids(db_resource.data) == []
 
 
 def test_namespace(pg_session, monkeypatch, mocker):
@@ -482,6 +530,51 @@ def test_work_instance_bnode(pg_session, monkeypatch):
             work.instances[0].uri
             == "https://bcld.info/instances/2B8CE2D3-BBD2-4F30-94BB-F382F39E5320"
         ), "bnode turned into URI"
+
+
+def test_other_resources_autoflush_disabled(engine):
+    """
+    save_graph must link Other Resources even when the session has autoflush
+    disabled (as the bluecore_api session does). Without an explicit flush
+    before _link, its uri lookups don't see the just-added rows, so the link
+    rows are built with null foreign keys and commit raises NotNullViolation.
+    """
+    pg_session = sessionmaker(bind=engine, autoflush=False)
+
+    jsonld_object = {
+        "@context": CONTEXT,
+        "@id": "https://bcld.info/works/9999aaaa-0000-1111-2222-333344445555",
+        "@type": BF.Work,
+        "title": {"@type": "Title", "mainTitle": "Gravity's Rainbow"},
+        "contribution": {
+            "@type": ["Contribution", "PrimaryContribution"],
+            "agent": {
+                "@id": "http://id.loc.gov/rwo/agents/n79099184",
+                "@type": ["Agent", "Person"],
+                "rdfs:label": "Pynchon, Thomas",
+            },
+            "role": {
+                "@id": "http://id.loc.gov/vocabulary/relators/aut",
+                "@type": "Role",
+                "rdfs:label": "author",
+            },
+        },
+    }
+
+    save_graph(pg_session, load_jsonld(jsonld_object))
+
+    with pg_session() as session:
+        work = (
+            session.query(Work)
+            .where(
+                Work.uri
+                == "https://bcld.info/works/9999aaaa-0000-1111-2222-333344445555"
+            )
+            .first()
+        )
+        assert work is not None
+        # the two Other Resources are linked, with non-null foreign keys
+        assert len(work.other_resources) == 2
 
 
 def test_other_resources(pg_session):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,7 @@ from bluecore_models.models import (
     Hub,
     Instance,
     OtherResource,
+    Profile,
     ResourceBibframeClass,
     Version,
     Work,
@@ -87,21 +88,24 @@ def test_other_resource(pg_session):
         assert other_resource.data["rdfs:label"] == "test"
         assert other_resource.created_at
         assert other_resource.updated_at
-        assert other_resource.is_profile is False
 
 
-def test_other_resource_profile(pg_session):
+def test_profile(pg_session):
     """
-    OtherResource "profiles" are not framed since they aren't necessarily JSON-LD
-    and won't have a URI associated with them.
+    Profiles are not framed since Sinopia Editor expects them to be a particular shape.
     """
     with pg_session() as session:
-        session.add(OtherResource(is_profile=True, data={"foo": "bar"}))
+        session.add(Profile(data={"foo": "bar"}))
         session.commit()
 
     with pg_session() as session:
-        other = session.query(OtherResource).order_by(OtherResource.id).all()[-1]
-        assert other.data["foo"] == "bar"
+        profile = session.query(Profile).order_by(Profile.id).all()[-1]
+        assert profile.data["foo"] == "bar"
+        assert profile.type == "profiles"
+        # Profiles are versioned like Works/Instances/Hubs.
+        versions = session.query(Version).where(Version.resource_id == profile.id).all()
+        assert len(versions) == 1
+        assert versions[0].data["foo"] == "bar"
 
 
 def test_versions(pg_session, user_context):

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -228,7 +228,6 @@ def _seed_authorities(pg_session) -> None:
                     uri=uri,
                     data={"seed": i},
                     type="other_resources",
-                    is_profile=False,
                 )
             )
         session.commit()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from bluecore_models.utils.graph import (
     generate_entity_graph,
     init_graph,
     load_jsonld,
+    replace_uri,
     _expand_bnode,
 )
 
@@ -51,6 +52,31 @@ def test_generate_entity_graph():
         subject=work_uri, predicate=rdflib.DCTERMS.isPartOf
     )
     assert work_dcterm_part_of is None
+
+
+def test_replace_uri():
+    """
+    replace_uri rewrites a URI everywhere it appears -- as a subject and as an
+    object referenced by other resources.
+    """
+    old = URIRef("http://example.com/old")
+    new = URIRef("http://example.com/new")
+    other = URIRef("http://example.com/other")
+
+    graph = init_graph()
+    # old appears as a subject...
+    graph.add((old, rdflib.RDF.type, BF.Work))
+    graph.add((old, BF.title, Literal("A title")))
+    # ...and as an object referenced by another resource.
+    graph.add((other, BF.relatedTo, old))
+
+    replace_uri(graph, old, new)
+
+    # old is gone from every position, new takes its place.
+    assert old not in set(graph.subjects()) | set(graph.objects())
+    assert (new, rdflib.RDF.type, BF.Work) in graph
+    assert (new, BF.title, Literal("A title")) in graph
+    assert (other, BF.relatedTo, new) in graph
 
 
 def test_bnode_expansion():

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -228,8 +228,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -660,10 +660,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [


### PR DESCRIPTION
Add Template as a first-class resource, split from OtherResource

Profiles (formerly OtherResources flagged with is_profile=True) become their own polymorphic ResourceBase subclass:

- New Profile model (type='templates'), versioned like Works/Instances/Hubs
- set_jsonld skips framing for Profiles via isinstance instead of is_profile
- Remove is_profile column from OtherResource
- Migration 20260626: create profiles table, move is_profile rows, mint uuid + .../profiles/{uuid} uris, drop other_resources.is_profile
- Update tests

For context on why this refactor is needed see: https://github.com/blue-core-lod/sinopia_editor/issues/113