### PR TITLE
Change agent URIRef in bluecore_graph.py

### DIFF
--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -260,7 +260,7 @@ class BluecoreGraph:
         bluecore_uri: URIRef,
         source_uri: URIRef,
         status: URIRef = URIRef("http://id.loc.gov/vocabulary/mstatus/c"),
-        agent: URIRef = URIRef("http://id.loc.gov/vocabulary/organizations/bcld"),
+        agent: URIRef = URIRef("http://id.loc.gov/vocabulary/organizations/cbc"),
         desc_auth: URIRef = URIRef("http://id.loc.gov/vocabulary/marcauthen/pcc"),
         desc_lang: URIRef = URIRef("http://id.loc.gov/vocabulary/languages/eng"),
         desc_level: URIRef = URIRef("http://id.loc.gov/ontologies/bibframe-2-6-0/"),


### PR DESCRIPTION
## Summary
Updates the agent URI in `adminMetadata` to use the correct 
Library of Congress vocabulary identifier.

## Changes
- Updated `agent` URIRef in `bluecore_graph.py` (line 263)
- Old: `http://id.loc.gov/vocabulary/organizations/bcld`
- New: `http://id.loc.gov/vocabulary/organizations/cbc`

## Related Issue
Closes #120

## Type of Change
- [x] Bug fix / Enhancement