### PR TITLE
128 remove triples by type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.22.1"
+version = "0.23.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -37,6 +37,13 @@ RETRYABLE_PG_ERRORS = (
 # How many times to attempt save() before giving up on serialization failures.
 SAVE_MAX_ATTEMPTS = 3
 
+# (predicate, rdf:type) pairs identifying blank nodes that are stripped out of
+# a resource's graph before it is persisted to the database, e.g. removing
+# OCLC number identifiers that shouldn't be exposed.
+EXCLUDED_TRIPLE_TYPES = [
+    (BF.identifiedBy, BF.OclcNumber),
+]
+
 
 def _is_retryable_pg_error(error: BaseException) -> bool:
     """
@@ -339,6 +346,21 @@ class BluecoreGraph:
             # remove the link from the resource to the AdminMetadata node
             graph.remove((s, BF.adminMetadata, admin_metadata))
 
+    def _remove_triples_by_type(
+        self, graph: Graph, predicate: URIRef, type_: URIRef
+    ) -> None:
+        """
+        Removes blank nodes reachable via predicate that are rdf:typed as
+        type_ (e.g. predicate=BF.identifiedBy, type_=BF.OclcNumber) from the
+        supplied graph, along with the predicate assertion that points to them.
+        """
+        for s, obj in list(graph.subject_objects(predicate=predicate)):
+            if not isinstance(obj, BNode):
+                continue
+            if (obj, RDF.type, type_) in graph:
+                self._remove_bnode(graph, obj)
+                graph.remove((s, predicate, obj))
+
     def _subject(self, graph: Graph, class_: Node | None = None) -> IdentifiedNode:
         """
         Gets the subject from the supplied graph using the RDF type class. The
@@ -526,6 +548,8 @@ class BluecoreGraph:
 
         for g in resources:
             uri = self._subject(g, class_)
+            for predicate, type_ in EXCLUDED_TRIPLE_TYPES:
+                self._remove_triples_by_type(g, predicate, type_)
             data = json.loads(g.serialize(format="json-ld"))
 
             obj = session.query(sqla_class).where(sqla_class.uri == uri).first()

--- a/tests/test_bluecore_graph.py
+++ b/tests/test_bluecore_graph.py
@@ -65,6 +65,40 @@ def test_bluecore_graph():
             )
 
 
+def test_remove_oclc_number_identifiers():
+    """
+    bf:identifiedBy blank nodes typed bf:OclcNumber are stripped out, while
+    other identifier types (e.g. bf:Lccn) are left in place.
+    """
+    g = Graph()
+    g.parse(
+        data="""
+        @prefix bf: <http://id.loc.gov/ontologies/bibframe/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        <https://dev.bcld.info/instances/0ca0f64e-d086-4309-a3e7-22ed061ad7e8>
+            a bf:Instance ;
+            bf:identifiedBy [ a bf:Lccn ; rdf:value "  2022508031" ] ;
+            bf:identifiedBy [ a bf:OclcNumber ; rdf:value "on1267753195" ] .
+        """,
+        format="turtle",
+    )
+    bg = BluecoreGraph(g)
+    instances = bg.instances()
+    assert len(instances) == 1
+    instance_graph = instances[0]
+
+    bg._remove_triples_by_type(instance_graph, BF.identifiedBy, BF.OclcNumber)
+
+    identifier_types = {
+        identifier_type
+        for _, identifier in instance_graph.subject_objects(BF.identifiedBy)
+        for identifier_type in instance_graph.objects(identifier, RDF.type)
+    }
+    assert BF.OclcNumber not in identifier_types
+    assert BF.Lccn in identifier_types
+
+
 def test_save(pg_session):
     """
     Load a real CBD graph from disk, persist to the database, and check that the

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -229,8 +229,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -663,10 +663,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [


### PR DESCRIPTION
Fixes #128 
```
# (predicate, rdf:type) pairs identifying blank nodes that are stripped out of
# a resource's graph before it is persisted to the database, e.g. removing
# OCLC number identifiers that shouldn't be exposed.
EXCLUDED_TRIPLE_TYPES = [
    (BF.identifiedBy, BF.OclcNumber),
]
```
Other tuples can be added in the future as needed.