### PR TITLE
Speed up save_graph (~2.2x on a real Airflow batch load)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ All tests are located in the tests/ directory.
 
 ---
 
+## 📊 Benchmarking `save_graph`
+
+`benchmarks/save_graph_bench.py` persists a set of Bibframe graphs through the
+real save path (URI minting, resource save, linking, bf-class updates) and
+reports throughput (graphs/s, triples/s). With `--profile` it prints a cProfile
+hot-spot report, which is handy for finding where the save path spends its time.
+
+It writes to a Postgres, so first start one — the [Run Postgres with Docker](#-run-postgres-with-docker)
+command above works (it creates a `bluecore` database). Then point the benchmark
+at it with `--database-url` (or the `DATABASE_URL` env var); the benchmark
+creates the schema if it isn't there.
+
+#### Run the benchmark (50 saves of the sample graphs)
+```
+uv run python benchmarks/save_graph_bench.py \
+  --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \
+  --count 50
+```
+
+#### Print a cProfile hot-spot report
+Add `--profile`:
+```
+uv run python benchmarks/save_graph_bench.py \
+  --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \
+  --count 50 --profile
+```
+
+Other options:
+- `--reset` — `TRUNCATE` the resource tables first (don't point this at data you care about).
+- `--input "<glob>"` — RDF files to load (defaults to `tests/data/*.jsonld`); pass a
+  directory of `.rdf`/`.jsonld` records for a larger, more representative run.
+
+💡 Since the graph content doesn't change *which* code runs, reusing a few sample
+records many times (`--count`) is a fair, repeatable way to measure changes to
+the save path (e.g. before/after an optimization).
+
+---
+
 ## ⬆️ Publishing to Pypi
 To publish the `bluecore-models` to [pypi](https://pypi.org/project/bluecore-models/), the
 following steps need to be taken. 

--- a/benchmarks/save_graph_bench.py
+++ b/benchmarks/save_graph_bench.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Benchmark and profile ``bluecore_models.save_graph``.
+
+Persists a set of Bibframe graphs through the real save path (URI minting,
+resource save, linking, bf-class updates) and reports throughput. With
+``--profile`` it also prints a cProfile hot-spot report, which is how the
+``_link`` / ``get_bf_classes`` costs were originally found.
+
+The graph content doesn't affect *which* code runs, so reusing a few sample
+records many times (``--count``) is a fair, repeatable way to measure changes to
+the save path.
+
+Requires a Postgres to write to. Point it at any database via ``--database-url``
+(or the ``DATABASE_URL`` env var); the local bluecore-stack DB works well:
+
+    uv run python benchmarks/save_graph_bench.py \\
+        --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \\
+        --count 50 --profile
+
+Use ``--reset`` to TRUNCATE the resource tables first (don't point that at a
+database you care about).
+"""
+import argparse
+import cProfile
+import glob
+import io
+import os
+import pstats
+import time
+
+import rdflib
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from bluecore_models.models import Base
+from bluecore_models.models.pg_ext_func import PG_EXT_FUNC
+from bluecore_models.bluecore_graph import save_graph
+
+DEFAULT_INPUT = os.path.join(os.path.dirname(__file__), "..", "tests", "data", "*.jsonld")
+RESET_TABLES = [
+    "bibframe_other_resources",
+    "resource_bibframe_classes",
+    "versions",
+    "works",
+    "instances",
+    "hubs",
+    "other_resources",
+    "resource_base",
+    "bibframe_classes",
+]
+
+
+def ensure_schema(engine) -> None:
+    """Best-effort: create the custom functions + tables if they're not present."""
+    with engine.begin() as conn:
+        for stmt in PG_EXT_FUNC:
+            try:
+                conn.execute(text(stmt))
+            except Exception as exc:  # pragma: no cover - setup convenience
+                print(f"  (skipped ext stmt: {exc})")
+    Base.metadata.create_all(engine)
+
+
+def reset(engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text("TRUNCATE TABLE " + ", ".join(RESET_TABLES) + " RESTART IDENTITY CASCADE")
+        )
+
+
+def load_graphs(pattern: str) -> list[rdflib.Graph]:
+    graphs = []
+    for path in sorted(glob.glob(pattern)):
+        fmt = rdflib.util.guess_format(path) or "json-ld"
+        g = rdflib.Graph()
+        try:
+            g.parse(location=path, format=fmt)
+        except Exception as exc:
+            print(f"  (skipped {os.path.basename(path)}: {exc})")
+            continue
+        if len(g):
+            graphs.append(g)
+    return graphs
+
+
+def run(graphs, session_maker, count):
+    saved = 0
+    triples = 0
+    for i in range(count):
+        g = graphs[i % len(graphs)]
+        # copy so repeated saves don't accumulate minted URIs on the same object
+        gc = rdflib.Graph()
+        for triple in g:
+            gc.add(triple)
+        save_graph(session_maker, gc, namespace="https://bcld.info/")
+        saved += 1
+        triples += len(g)
+    return saved, triples
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    ap.add_argument("--count", type=int, default=25, help="number of save_graph calls")
+    ap.add_argument("--input", default=DEFAULT_INPUT, help="glob of RDF files to load")
+    ap.add_argument("--profile", action="store_true", help="print cProfile hot spots")
+    ap.add_argument("--reset", action="store_true", help="TRUNCATE resource tables first")
+    args = ap.parse_args()
+
+    if not args.database_url:
+        ap.error("provide --database-url or set DATABASE_URL")
+
+    engine = create_engine(args.database_url)
+    ensure_schema(engine)
+    if args.reset:
+        reset(engine)
+    session_maker = sessionmaker(bind=engine)
+
+    graphs = load_graphs(args.input)
+    if not graphs:
+        ap.error(f"no graphs loaded from {args.input}")
+    print(f"loaded {len(graphs)} sample graph(s); running {args.count} save_graph calls")
+
+    # warm up (schema caches, first-insert vs update path) — excluded from timing
+    run(graphs, session_maker, min(len(graphs), args.count))
+
+    profiler = cProfile.Profile() if args.profile else None
+    t0 = time.time()
+    if profiler:
+        profiler.enable()
+    saved, triples = run(graphs, session_maker, args.count)
+    if profiler:
+        profiler.disable()
+    wall = time.time() - t0
+
+    print(f"\n{saved} saves in {wall:.1f}s  =>  {saved / wall:.1f} graphs/s, "
+          f"{triples / wall:.0f} triples/s")
+
+    if profiler:
+        for sort, label, n in (("cumulative", "CUMULATIVE", 25), ("tottime", "SELF", 20)):
+            s = io.StringIO()
+            pstats.Stats(profiler, stream=s).sort_stats(sort).print_stats(n)
+            print(f"\n{'=' * 60}\nTOP {n} by {label} time\n{'=' * 60}\n{s.getvalue()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/save_graph_bench.py
+++ b/benchmarks/save_graph_bench.py
@@ -20,6 +20,7 @@ Requires a Postgres to write to. Point it at any database via ``--database-url``
 Use ``--reset`` to TRUNCATE the resource tables first (don't point that at a
 database you care about).
 """
+
 import argparse
 import cProfile
 import glob
@@ -36,7 +37,9 @@ from bluecore_models.models import Base
 from bluecore_models.models.pg_ext_func import PG_EXT_FUNC
 from bluecore_models.bluecore_graph import save_graph
 
-DEFAULT_INPUT = os.path.join(os.path.dirname(__file__), "..", "tests", "data", "*.jsonld")
+DEFAULT_INPUT = os.path.join(
+    os.path.dirname(__file__), "..", "tests", "data", "*.jsonld"
+)
 RESET_TABLES = [
     "bibframe_other_resources",
     "resource_bibframe_classes",
@@ -64,7 +67,11 @@ def ensure_schema(engine) -> None:
 def reset(engine) -> None:
     with engine.begin() as conn:
         conn.execute(
-            text("TRUNCATE TABLE " + ", ".join(RESET_TABLES) + " RESTART IDENTITY CASCADE")
+            text(
+                "TRUNCATE TABLE "
+                + ", ".join(RESET_TABLES)
+                + " RESTART IDENTITY CASCADE"
+            )
         )
 
 
@@ -99,12 +106,16 @@ def run(graphs, session_maker, count):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
     ap.add_argument("--count", type=int, default=25, help="number of save_graph calls")
     ap.add_argument("--input", default=DEFAULT_INPUT, help="glob of RDF files to load")
     ap.add_argument("--profile", action="store_true", help="print cProfile hot spots")
-    ap.add_argument("--reset", action="store_true", help="TRUNCATE resource tables first")
+    ap.add_argument(
+        "--reset", action="store_true", help="TRUNCATE resource tables first"
+    )
     args = ap.parse_args()
 
     if not args.database_url:
@@ -119,7 +130,9 @@ def main():
     graphs = load_graphs(args.input)
     if not graphs:
         ap.error(f"no graphs loaded from {args.input}")
-    print(f"loaded {len(graphs)} sample graph(s); running {args.count} save_graph calls")
+    print(
+        f"loaded {len(graphs)} sample graph(s); running {args.count} save_graph calls"
+    )
 
     # warm up (schema caches, first-insert vs update path) — excluded from timing
     run(graphs, session_maker, min(len(graphs), args.count))
@@ -133,11 +146,16 @@ def main():
         profiler.disable()
     wall = time.time() - t0
 
-    print(f"\n{saved} saves in {wall:.1f}s  =>  {saved / wall:.1f} graphs/s, "
-          f"{triples / wall:.0f} triples/s")
+    print(
+        f"\n{saved} saves in {wall:.1f}s  =>  {saved / wall:.1f} graphs/s, "
+        f"{triples / wall:.0f} triples/s"
+    )
 
     if profiler:
-        for sort, label, n in (("cumulative", "CUMULATIVE", 25), ("tottime", "SELF", 20)):
+        for sort, label, n in (
+            ("cumulative", "CUMULATIVE", 25),
+            ("tottime", "SELF", 20),
+        ):
             s = io.StringIO()
             pstats.Stats(profiler, stream=s).sort_stats(sort).print_stats(n)
             print(f"\n{'=' * 60}\nTOP {n} by {label} time\n{'=' * 60}\n{s.getvalue()}")

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -195,8 +195,19 @@ class BluecoreGraph:
                         # link rows with null foreign keys.
                         session.flush()
 
-                        # link all the works, instances and other resources together in the db
-                        self._link(session)
+                        # link all the works, instances and other resources together in the db.
+                        # _link issues many per-uri lookups; with autoflush on, each one
+                        # re-flushes the pending link changes (and re-fires update events /
+                        # bf-class recomputation). The resources it reads were already
+                        # flushed above, so turn autoflush off for the link phase and let
+                        # commit() do the single final flush. (bluecore_api's session already
+                        # runs with autoflush disabled.)
+                        prev_autoflush = session.autoflush
+                        session.autoflush = False
+                        try:
+                            self._link(session)
+                        finally:
+                            session.autoflush = prev_autoflush
 
                         # all changes are part of one transaction!
                         session.commit()

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -725,7 +725,9 @@ class BluecoreGraph:
                 if other_uri in g.objects():
                     instance_uri = self._subject(g, BF.Instance)
                     logger.info(f"linking {instance_uri} to {other_uri}")
-                    instance_model = self._resolve(session, Instance, instance_uri, cache)
+                    instance_model = self._resolve(
+                        session, Instance, instance_uri, cache
+                    )
                     other_model = self._resolve(
                         session, OtherResource, other_uri, cache
                     )
@@ -735,7 +737,9 @@ class BluecoreGraph:
                         )
                     )
 
-    def _delete_other_links(self, class_: URIRef, session: Session, cache: dict) -> None:
+    def _delete_other_links(
+        self, class_: URIRef, session: Session, cache: dict
+    ) -> None:
         """
         Delete existing links to OtherResources so that they can be replaced
         with new ones.

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -108,7 +108,38 @@ class BluecoreGraph:
             namespace += "/"
         self.namespace = Namespace(namespace)
         self.graph = graph
+        # The per-entity subgraph extractions (works/instances/hubs/others) are
+        # expensive and get called repeatedly across the save. We cache them keyed
+        # on _revision, which is bumped every time the graph is mutated so the
+        # cache can't go stale. Every mutation of self.graph funnels through
+        # _infer (once, here) and _switch_uris (during minting) -- keep it that
+        # way, or bump _revision at any new mutation site (see _bump_revision).
+        self._revision = 0
+        self._subgraph_cache: dict[str, tuple[int, list[Graph]]] = {}
         self._infer()
+
+    def _bump_revision(self) -> None:
+        """
+        Record that self.graph has been mutated, invalidating the subgraph cache.
+        Call this from anywhere that changes self.graph.
+        """
+        self._revision += 1
+
+    def _subgraphs(self, key: str, compute) -> list[Graph]:
+        """
+        Return the cached subgraph list for `key`, recomputing it (via `compute`)
+        only when the graph has changed since it was last cached. The cache is
+        keyed on _revision, so it invalidates itself whenever the graph is mutated
+        (see _bump_revision).
+
+        The returned graphs are shared/cached -- callers must not mutate them in
+        place (copy first, as _save does).
+        """
+        cached = self._subgraph_cache.get(key)
+        if cached is None or cached[0] != self._revision:
+            cached = (self._revision, compute())
+            self._subgraph_cache[key] = cached
+        return cached[1]
 
     def works(self) -> list[Graph]:
         """
@@ -116,32 +147,37 @@ class BluecoreGraph:
         distinct Work. Excludes Hubs, which LC catalog data types as both bf:Hub
         and bf:Work; they are handled separately by hubs().
         """
-        return [
-            generate_entity_graph(self.graph, s)
-            for s in self.graph.subjects(RDF.type, BF.Work)
-            if (s, RDF.type, BF.Hub) not in self.graph
-        ]
+        return self._subgraphs(
+            "works",
+            lambda: [
+                generate_entity_graph(self.graph, s)
+                for s in self.graph.subjects(RDF.type, BF.Work)
+                if (s, RDF.type, BF.Hub) not in self.graph
+            ],
+        )
 
     def hubs(self) -> list[Graph]:
         """
         Returns a list of Bibframe Hub rdflib Graphs, where each graph is for a
         distinct Hub.
         """
-        return self._extract_subgraphs(BF.Hub)
+        return self._subgraphs("hubs", lambda: self._extract_subgraphs(BF.Hub))
 
     def instances(self) -> list[Graph]:
         """
         Returns a list of Bibframe Instance rdflib Graphs, where each graph is for a
         distinct Instance.
         """
-        return self._extract_subgraphs(BF.Instance)
+        return self._subgraphs(
+            "instances", lambda: self._extract_subgraphs(BF.Instance)
+        )
 
     def others(self) -> list[Graph]:
         """
         Return a list of "Other Resource" rdflib Graphs, where each graph is for a
         distinct resource.
         """
-        return self._extract_others()
+        return self._subgraphs("others", self._extract_others)
 
     def save(
         self, session_maker: sessionmaker, max_attempts: int = SAVE_MAX_ATTEMPTS
@@ -219,6 +255,7 @@ class BluecoreGraph:
         """
         Infer some triples that we rely on, and which may be missing.
         """
+        self._bump_revision()  # mutates self.graph
 
         # create inverse properties
         inverse_properties = [
@@ -511,6 +548,7 @@ class BluecoreGraph:
         A bibframe:derivedFrom assertion is added to record the relationship
         if the derived_from is URIRef.
         """
+        self._bump_revision()  # replace_uri + _generate_admin_metadata mutate self.graph
         replace_uri(self.graph, derived_from, bluecore_uri)
         # only add derivedFrom assertions for URIs
         if isinstance(derived_from, URIRef):
@@ -531,6 +569,15 @@ class BluecoreGraph:
 
     def _is_bluecore_uri(self, uri) -> bool:
         return uri in self.namespace
+
+    @staticmethod
+    def _copy_graph(graph: Graph) -> Graph:
+        """Return a copy of an rdflib Graph (triples + namespace bindings)."""
+        copy = Graph()
+        for prefix, ns in graph.namespaces():
+            copy.bind(prefix, ns)
+        copy += graph
+        return copy
 
     def _save(self, class_: URIRef | None, session: Session) -> None:
         """
@@ -569,6 +616,9 @@ class BluecoreGraph:
         }
 
         for g, uri in zip(resources, subjects):
+            # work on a copy: the subgraphs are cached and reused by later phases
+            # (e.g. _link), so we must not strip triples out of the shared one.
+            g = self._copy_graph(g)
             for predicate, type_ in EXCLUDED_TRIPLE_TYPES:
                 self._remove_triples_by_type(g, predicate, type_)
             data = json.loads(g.serialize(format="json-ld"))

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -557,13 +557,23 @@ class BluecoreGraph:
         if class_ is None:
             resources = sorted(resources, key=lambda g: str(self._subject(g, class_)))
 
-        for g in resources:
-            uri = self._subject(g, class_)
+        # Fetch the resources of this batch that already exist in a single query,
+        # keyed by uri, rather than a SELECT per resource -- so re-saves and large
+        # batches don't fan out into a round-trip each.
+        subjects = [self._subject(g, class_) for g in resources]
+        existing = {
+            obj.uri: obj
+            for obj in session.query(sqla_class).where(
+                sqla_class.uri.in_([str(uri) for uri in subjects])
+            )
+        }
+
+        for g, uri in zip(resources, subjects):
             for predicate, type_ in EXCLUDED_TRIPLE_TYPES:
                 self._remove_triples_by_type(g, predicate, type_)
             data = json.loads(g.serialize(format="json-ld"))
 
-            obj = session.query(sqla_class).where(sqla_class.uri == uri).first()
+            obj = existing.get(str(uri))
 
             if obj:
                 obj.data = data

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -586,6 +586,14 @@ class BluecoreGraph:
         Save relations between Instances, Works and Other Resources in the graph.
         """
 
+        # Cache resource lookups for the duration of this link operation. _link
+        # resolves the same Works, Instances and Other Resources repeatedly (a
+        # Work is re-queried for every Other Resource it links to, etc.); caching
+        # by (type, uri) turns those repeats into a single query each. Every
+        # resource was flushed by save() before _link runs, so the first lookup
+        # already sees it.
+        cache: dict[tuple, object] = {}
+
         # use bibframe:instanceOf assertions to link instances with works
         #
         # Maybe we should have a simple inference step early on that infers missing
@@ -600,8 +608,8 @@ class BluecoreGraph:
             key=lambda pair: (str(pair[0]), str(pair[1])),
         ):
             logger.info(f"linking {s} to {o}")
-            instance = self._get_first(session, Instance, s)
-            work = self._get_first(session, Work, o)
+            instance = self._get_first(session, Instance, s, cache)
+            work = self._get_first(session, Work, o, cache)
             instance.work = work
             session.add(instance)
 
@@ -611,8 +619,8 @@ class BluecoreGraph:
             key=lambda pair: (str(pair[0]), str(pair[1])),
         ):
             logger.info(f"linking {s} to {o}")
-            work = self._get_first(session, Work, s)
-            instance = self._get_first(session, Instance, o)
+            work = self._get_first(session, Work, s, cache)
+            instance = self._get_first(session, Instance, o, cache)
             instance.work = work
             session.add(instance)
 
@@ -622,8 +630,8 @@ class BluecoreGraph:
 
         # first remove any existing Other Resource linkages between Works and
         # Instances so that they can be replaced with the new ones
-        self._delete_other_links(BF.Work, session)
-        self._delete_other_links(BF.Instance, session)
+        self._delete_other_links(BF.Work, session, cache)
+        self._delete_other_links(BF.Instance, session, cache)
 
         work_graphs = sorted(self.works(), key=lambda g: str(self._subject(g, BF.Work)))
         instance_graphs = sorted(
@@ -640,11 +648,9 @@ class BluecoreGraph:
                 if other_uri in g.objects():
                     work_uri = self._subject(g, BF.Work)
                     logger.info(f"linking {work_uri} to {other_uri}")
-                    work_model = session.query(Work).where(Work.uri == work_uri).first()
-                    other_model = (
-                        session.query(OtherResource)
-                        .where(OtherResource.uri == other_uri)
-                        .first()
+                    work_model = self._resolve(session, Work, work_uri, cache)
+                    other_model = self._resolve(
+                        session, OtherResource, other_uri, cache
                     )
                     session.add(
                         BibframeOtherResources(
@@ -659,15 +665,9 @@ class BluecoreGraph:
                 if other_uri in g.objects():
                     instance_uri = self._subject(g, BF.Instance)
                     logger.info(f"linking {instance_uri} to {other_uri}")
-                    instance_model = (
-                        session.query(Instance)
-                        .where(Instance.uri == instance_uri)
-                        .first()
-                    )
-                    other_model = (
-                        session.query(OtherResource)
-                        .where(OtherResource.uri == other_uri)
-                        .first()
+                    instance_model = self._resolve(session, Instance, instance_uri, cache)
+                    other_model = self._resolve(
+                        session, OtherResource, other_uri, cache
                     )
                     session.add(
                         BibframeOtherResources(
@@ -675,7 +675,7 @@ class BluecoreGraph:
                         )
                     )
 
-    def _delete_other_links(self, class_: URIRef, session: Session) -> None:
+    def _delete_other_links(self, class_: URIRef, session: Session, cache: dict) -> None:
         """
         Delete existing links to OtherResources so that they can be replaced
         with new ones.
@@ -690,20 +690,33 @@ class BluecoreGraph:
 
         for g in graphs:
             uri = self._subject(g, class_)
-            bf_resource = (
-                session.query(sqla_class).where(sqla_class.uri == str(uri)).first()
-            )
+            bf_resource = self._resolve(session, sqla_class, uri, cache)
 
             session.query(BibframeOtherResources).filter(
                 BibframeOtherResources.bibframe_resource == bf_resource
             ).delete()
 
-    def _get_first(self, session: Session, sqla_class: Instance | Work, uri: Node):
+    def _resolve(self, session: Session, sqla_class, uri: Node, cache: dict):
+        """
+        Look up a resource of the given type by uri, caching the result (keyed by
+        type + uri) so repeated lookups within a single _link operation only hit
+        the database once. Returns None if there is no matching resource.
+        """
+        key = (sqla_class, str(uri))
+        if key not in cache:
+            cache[key] = (
+                session.query(sqla_class).where(sqla_class.uri == str(uri)).first()
+            )
+        return cache[key]
+
+    def _get_first(
+        self, session: Session, sqla_class: Instance | Work, uri: Node, cache: dict
+    ):
         """
         Look up the first object of the given type in the database and return it
         or throw an exception.
         """
-        obj = session.query(sqla_class).where(sqla_class.uri == uri).first()
+        obj = self._resolve(session, sqla_class, uri, cache)
         if obj is None:
             raise Exception(f"Unable to find in db: uri={uri}")
 


### PR DESCRIPTION
## Summary

Speeds up `save_graph()` (the DB-write step of a Blue Core load), plus a
reusable benchmark/profiler tool used to find and measure the hot spots.

**Validated end-to-end in a real Airflow instance:** a test batch load via
`bluecore-stack`'s `scripts/dev/load-data` (the default dev dataset,
`sample/batch.jsonld`) went from **~1:40 to ~0:45 (~2.2×)**.

Before:
<img width="1538" height="1050" alt="Screenshot 2026-07-22 at 8 57 24 PM" src="https://github.com/user-attachments/assets/a0f8fe25-eb30-4f8f-8b71-c319cb070ceb" />

After:
<img width="1538" height="1050" alt="Screenshot 2026-07-22 at 9 55 34 PM" src="https://github.com/user-attachments/assets/f22ff950-f848-460e-a563-1bbd63b11758" />


## Changes

Profiling `save_graph` showed it is CPU-bound in Python (rdflib / bluecore_models),
not the database (~9% of time). The hot spots, addressed in order:

1. **Disable autoflush during `_link`.** `_link` issues many per-uri
   `Query.first()` lookups; with autoflush on, each one re-flushed the pending
   link changes and re-fired ORM update events (bf-class recomputation). The
   resources it reads are already flushed just before it runs, so autoflush adds
   no correctness there — disable it for the link phase and let `commit()` do the
   single final flush. (`bluecore_api`'s session already runs autoflush-off.)
2. **Cache resource lookups within `_link`** (a Work is otherwise re-queried for
   every Other Resource it links to). First lookup hits the DB; repeats are
   served from a per-link cache.
3. **Batch `_save` existence checks** into one `uri IN (...)` query per resource
   type instead of a SELECT per resource.
4. **Memoize entity-subgraph extraction** (`works`/`instances`/`hubs`/`others`),
   the dominant cost on real CBD records (many Other Resources, deep blank-node
   trees). These are rebuilt ~dozens of times per save across mint → save → link.

## Footgun guard for the memoization

The subgraph cache is keyed on a `_revision` counter that is bumped whenever
`self.graph` is mutated, so **the cache invalidates itself** and can't go stale.
Every mutation funnels through `_infer` (once) and `_switch_uris` (minting), which
call `_bump_revision()` — the documented hook for any future mutation site.

> A `Graph` subclass that bumped the counter on every mutation would be more
> automatic, but rdflib's SPARQL update does `type(g) is Graph` (exact type
> check), so a subclass breaks `replace_uri`.

The second footgun — a caller mutating a *shared cached* subgraph — is handled by
having `_save` strip excluded (OCLC) triples on a copy (`_copy_graph`), leaving
the cached subgraphs pristine for `_link`.

## Benchmark tool

`benchmarks/save_graph_bench.py` (documented in the README) reports throughput
and, with `--profile`, a cProfile hot-spot report. Points at any Postgres via
`--database-url` / `DATABASE_URL`.

## Measurements

- **Real Airflow, `scripts/dev/load-data` (batch.jsonld):** ~1:40 → ~0:45 (~2.2×).
- Standalone `benchmarks/save_graph_bench.py` (understates the end-to-end gain
  because it exercises the update path): `tests/data` sample graphs ~4.3×
  (11.1s → 2.6s / 40 saves); real CBD records ~22% (update path).
- Remaining `save_graph` time is now dominated by the actual DB inserts
  (`save_obj`) and rdflib serialize.

## Tests

Full suite passes (68 tests). ruff clean.

## Possible follow-up (not in this PR)

Batch the per-resource ORM inserts (bulk insert) — that's where the remaining
real-record time is; `save_obj` is otherwise irreducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
