### PR TITLE
Speed up save_graph (~2.2x) + prevent reference clobber

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ All tests are located in the tests/ directory.
 
 ---
 
+## 📊 Benchmarking `save_graph`
+
+`benchmarks/save_graph_bench.py` persists a set of Bibframe graphs through the
+real save path (URI minting, resource save, linking, bf-class updates) and
+reports throughput (graphs/s, triples/s). With `--profile` it prints a cProfile
+hot-spot report, which is handy for finding where the save path spends its time.
+
+It writes to a Postgres, so first start one — the [Run Postgres with Docker](#-run-postgres-with-docker)
+command above works (it creates a `bluecore` database). Then point the benchmark
+at it with `--database-url` (or the `DATABASE_URL` env var); the benchmark
+creates the schema if it isn't there.
+
+#### Run the benchmark (50 saves of the sample graphs)
+```
+uv run python benchmarks/save_graph_bench.py \
+  --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \
+  --count 50
+```
+
+#### Print a cProfile hot-spot report
+Add `--profile`:
+```
+uv run python benchmarks/save_graph_bench.py \
+  --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \
+  --count 50 --profile
+```
+
+Other options:
+- `--reset` — `TRUNCATE` the resource tables first (don't point this at data you care about).
+- `--input "<glob>"` — RDF files to load (defaults to `tests/data/*.jsonld`); pass a
+  directory of `.rdf`/`.jsonld` records for a larger, more representative run.
+
+💡 Since the graph content doesn't change *which* code runs, reusing a few sample
+records many times (`--count`) is a fair, repeatable way to measure changes to
+the save path (e.g. before/after an optimization).
+
+---
+
 ## ⬆️ Publishing to Pypi
 To publish the `bluecore-models` to [pypi](https://pypi.org/project/bluecore-models/), the
 following steps need to be taken. 

--- a/benchmarks/save_graph_bench.py
+++ b/benchmarks/save_graph_bench.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Benchmark and profile ``bluecore_models.save_graph``.
+
+Persists a set of Bibframe graphs through the real save path (URI minting,
+resource save, linking, bf-class updates) and reports throughput. With
+``--profile`` it also prints a cProfile hot-spot report, which is how the
+``_link`` / ``get_bf_classes`` costs were originally found.
+
+The graph content doesn't affect *which* code runs, so reusing a few sample
+records many times (``--count``) is a fair, repeatable way to measure changes to
+the save path.
+
+Requires a Postgres to write to. Point it at any database via ``--database-url``
+(or the ``DATABASE_URL`` env var); the local bluecore-stack DB works well:
+
+    uv run python benchmarks/save_graph_bench.py \\
+        --database-url postgresql+psycopg2://airflow:airflow@localhost:5432/bluecore \\
+        --count 50 --profile
+
+Use ``--reset`` to TRUNCATE the resource tables first (don't point that at a
+database you care about).
+"""
+
+import argparse
+import cProfile
+import glob
+import io
+import os
+import pstats
+import time
+
+import rdflib
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from bluecore_models.models import Base
+from bluecore_models.models.pg_ext_func import PG_EXT_FUNC
+from bluecore_models.bluecore_graph import save_graph
+
+DEFAULT_INPUT = os.path.join(
+    os.path.dirname(__file__), "..", "tests", "data", "*.jsonld"
+)
+RESET_TABLES = [
+    "bibframe_other_resources",
+    "resource_bibframe_classes",
+    "versions",
+    "works",
+    "instances",
+    "hubs",
+    "other_resources",
+    "resource_base",
+    "bibframe_classes",
+]
+
+
+def ensure_schema(engine) -> None:
+    """Best-effort: create the custom functions + tables if they're not present."""
+    with engine.begin() as conn:
+        for stmt in PG_EXT_FUNC:
+            try:
+                conn.execute(text(stmt))
+            except Exception as exc:  # pragma: no cover - setup convenience
+                print(f"  (skipped ext stmt: {exc})")
+    Base.metadata.create_all(engine)
+
+
+def reset(engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "TRUNCATE TABLE "
+                + ", ".join(RESET_TABLES)
+                + " RESTART IDENTITY CASCADE"
+            )
+        )
+
+
+def load_graphs(pattern: str) -> list[rdflib.Graph]:
+    graphs = []
+    for path in sorted(glob.glob(pattern)):
+        fmt = rdflib.util.guess_format(path) or "json-ld"
+        g = rdflib.Graph()
+        try:
+            g.parse(location=path, format=fmt)
+        except Exception as exc:
+            print(f"  (skipped {os.path.basename(path)}: {exc})")
+            continue
+        if len(g):
+            graphs.append(g)
+    return graphs
+
+
+def run(graphs, session_maker, count, update_other_resources=True):
+    saved = 0
+    triples = 0
+    for i in range(count):
+        g = graphs[i % len(graphs)]
+        # copy so repeated saves don't accumulate minted URIs on the same object
+        gc = rdflib.Graph()
+        for triple in g:
+            gc.add(triple)
+        save_graph(
+            session_maker,
+            gc,
+            namespace="https://bcld.info/",
+            update_other_resources=update_other_resources,
+        )
+        saved += 1
+        triples += len(g)
+    return saved, triples
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    ap.add_argument("--count", type=int, default=25, help="number of save_graph calls")
+    ap.add_argument("--input", default=DEFAULT_INPUT, help="glob of RDF files to load")
+    ap.add_argument("--profile", action="store_true", help="print cProfile hot spots")
+    ap.add_argument(
+        "--reset", action="store_true", help="TRUNCATE resource tables first"
+    )
+    ap.add_argument(
+        "--no-update-other-resources",
+        dest="update_other_resources",
+        action="store_false",
+        help="treat Other Resources as references (create-if-absent, never overwrite)",
+    )
+    args = ap.parse_args()
+
+    if not args.database_url:
+        ap.error("provide --database-url or set DATABASE_URL")
+
+    engine = create_engine(args.database_url)
+    ensure_schema(engine)
+    if args.reset:
+        reset(engine)
+    session_maker = sessionmaker(bind=engine)
+
+    graphs = load_graphs(args.input)
+    if not graphs:
+        ap.error(f"no graphs loaded from {args.input}")
+    print(
+        f"loaded {len(graphs)} sample graph(s); running {args.count} save_graph calls"
+    )
+
+    # warm up (schema caches, first-insert vs update path) — excluded from timing
+    run(
+        graphs, session_maker, min(len(graphs), args.count), args.update_other_resources
+    )
+
+    profiler = cProfile.Profile() if args.profile else None
+    t0 = time.time()
+    if profiler:
+        profiler.enable()
+    saved, triples = run(graphs, session_maker, args.count, args.update_other_resources)
+    if profiler:
+        profiler.disable()
+    wall = time.time() - t0
+
+    print(
+        f"\n{saved} saves in {wall:.1f}s  =>  {saved / wall:.1f} graphs/s, "
+        f"{triples / wall:.0f} triples/s"
+    )
+
+    if profiler:
+        for sort, label, n in (
+            ("cumulative", "CUMULATIVE", 25),
+            ("tottime", "SELF", 20),
+        ):
+            s = io.StringIO()
+            pstats.Stats(profiler, stream=s).sort_stats(sort).print_stats(n)
+            print(f"\n{'=' * 60}\nTOP {n} by {label} time\n{'=' * 60}\n{s.getvalue()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/save_graph_bench.py
+++ b/benchmarks/save_graph_bench.py
@@ -33,9 +33,9 @@ import rdflib
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
+from bluecore_models.bluecore_graph import save_graph
 from bluecore_models.models import Base
 from bluecore_models.models.pg_ext_func import PG_EXT_FUNC
-from bluecore_models.bluecore_graph import save_graph
 
 DEFAULT_INPUT = os.path.join(
     os.path.dirname(__file__), "..", "tests", "data", "*.jsonld"
@@ -59,7 +59,7 @@ def ensure_schema(engine) -> None:
         for stmt in PG_EXT_FUNC:
             try:
                 conn.execute(text(stmt))
-            except Exception as exc:  # pragma: no cover - setup convenience
+            except Exception as exc:  # noqa: BLE001  # pragma: no cover - setup convenience
                 print(f"  (skipped ext stmt: {exc})")
     Base.metadata.create_all(engine)
 
@@ -82,7 +82,7 @@ def load_graphs(pattern: str) -> list[rdflib.Graph]:
         g = rdflib.Graph()
         try:
             g.parse(location=path, format=fmt)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             print(f"  (skipped {os.path.basename(path)}: {exc})")
             continue
         if len(g):

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -241,6 +241,14 @@ class BluecoreGraph:
                 f"(attempt {retry_state.attempt_number} of {max_attempts})"
             )
 
+        # save resources from the graph to the database. Only the
+        # primary_class is authoritatively upserted; other kinds are
+        # references (create-if-absent, never overwrite).
+        # See _persist_resources.
+        # primary_class is None means every kind is authoritative.
+        def is_primary(kind) -> bool:
+            return primary_class is None or primary_class == kind
+
         # Strip the triples we never persist (see EXCLUDED_TRIPLE_TYPES) from the
         # graph once, before minting extracts subgraphs. The per-entity subgraphs
         # are then already clean, so _persist_resources can serialize the shared
@@ -261,14 +269,6 @@ class BluecoreGraph:
                     self._mint_all_uris(BF.Hub, session)
                     self._mint_all_uris(BF.Work, session)
                     self._mint_all_uris(BF.Instance, session)
-
-                    # save resources from the graph to the database. Only the
-                    # primary_class is authoritatively upserted; other kinds are
-                    # references (create-if-absent, never overwrite).
-                    # See _persist_resources.
-                    # primary_class is None means every kind is authoritative.
-                    def is_primary(kind) -> bool:
-                        return primary_class is None or primary_class == kind
 
                     self._persist_resources(BF.Hub, session, is_primary(BF.Hub))
                     self._persist_resources(BF.Work, session, is_primary(BF.Work))
@@ -701,7 +701,7 @@ class BluecoreGraph:
                 # its JSON-LD -- serializing and re-framing it would be wasted work
                 # (this is the hot path when batch-loading records that share many
                 # Other Resources).
-                logger.info(f"keeping existing {uri} (referenced, not primary)")
+                logger.debug(f"keeping existing {uri} (referenced, not primary)")
                 continue
 
             # Serialize the shared (cached) subgraph directly. save() already

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -69,16 +69,39 @@ def _is_retryable_pg_error(error: BaseException) -> bool:
 
 
 def save_graph(
-    session_maker: sessionmaker, graph: Graph, namespace="https://bcld.info/"
+    session_maker: sessionmaker,
+    graph: Graph,
+    namespace="https://bcld.info/",
+    primary_class=None,
+    update_other_resources: bool = True,
 ) -> Graph:
     """
     Use the supplied database sessionmaker to create a database session and
     persist all the resources found in the Graph. The possibly modified graph is
     returned, which will contain any new URIs that were minted, as well as
     bibframe:derivedFrom assertions for the original URIs.
+
+    primary_class marks which kind of resource the caller is authoritatively
+    writing: BF.Work, BF.Instance, BF.Hub, or the OtherResource model class.
+    Resources of that kind are fully upserted; resources of any other kind are
+    treated as references -- created if absent but never overwritten -- so a
+    reference (even one carrying a display label) can't clobber an existing full
+    description. When primary_class is None (e.g. the bulk loader) every resource
+    is authoritative, preserving the original behavior.
+
+    update_other_resources only applies when primary_class is None: set it False
+    to treat Other Resources as references (create-if-absent, never overwrite)
+    even on the bulk path. Batch loading of Works/Instances references many shared
+    Other Resources it doesn't need to re-describe; skipping those updates avoids
+    re-framing/re-writing each one on every record. (Their descriptions are then
+    maintained by a separate process.)
     """
     bg = BluecoreGraph(graph, namespace)
-    bg.save(session_maker)
+    bg.save(
+        session_maker,
+        primary_class=primary_class,
+        update_other_resources=update_other_resources,
+    )
     return bg.graph
 
 
@@ -122,7 +145,38 @@ class BluecoreGraph:
             namespace += "/"
         self.namespace = Namespace(namespace)
         self.graph = graph
+        # The per-entity subgraph extractions (works/instances/hubs/others) are
+        # expensive and get called repeatedly across the save. We cache them keyed
+        # on _revision, which is bumped every time the graph is mutated so the
+        # cache can't go stale. Every mutation of self.graph funnels through
+        # _infer (once, here) and _switch_uris (during minting) -- keep it that
+        # way, or bump _revision at any new mutation site (see _bump_revision).
+        self._revision = 0
+        self._subgraph_cache: dict[str, tuple[int, list[Graph]]] = {}
         self._infer()
+
+    def _bump_revision(self) -> None:
+        """
+        Record that self.graph has been mutated, invalidating the subgraph cache.
+        Call this from anywhere that changes self.graph.
+        """
+        self._revision += 1
+
+    def _subgraphs(self, key: str, compute) -> list[Graph]:
+        """
+        Return the cached subgraph list for `key`, recomputing it (via `compute`)
+        only when the graph has changed since it was last cached. The cache is
+        keyed on _revision, so it invalidates itself whenever the graph is mutated
+        (see _bump_revision).
+
+        The returned graphs are shared/cached -- callers must not mutate them in
+        place (copy first, or bump _revision if mutating self.graph).
+        """
+        cached = self._subgraph_cache.get(key)
+        if cached is None or cached[0] != self._revision:
+            cached = (self._revision, compute())
+            self._subgraph_cache[key] = cached
+        return cached[1]
 
     def works(self) -> list[Graph]:
         """
@@ -130,35 +184,44 @@ class BluecoreGraph:
         distinct Work. Excludes Hubs, which LC catalog data types as both bf:Hub
         and bf:Work; they are handled separately by hubs().
         """
-        return [
-            generate_entity_graph(self.graph, s)
-            for s in self.graph.subjects(RDF.type, BF.Work)
-            if (s, RDF.type, BF.Hub) not in self.graph
-        ]
+        return self._subgraphs(
+            "works",
+            lambda: [
+                generate_entity_graph(self.graph, s)
+                for s in self.graph.subjects(RDF.type, BF.Work)
+                if (s, RDF.type, BF.Hub) not in self.graph
+            ],
+        )
 
     def hubs(self) -> list[Graph]:
         """
         Returns a list of Bibframe Hub rdflib Graphs, where each graph is for a
         distinct Hub.
         """
-        return self._extract_subgraphs(BF.Hub)
+        return self._subgraphs("hubs", lambda: self._extract_subgraphs(BF.Hub))
 
     def instances(self) -> list[Graph]:
         """
         Returns a list of Bibframe Instance rdflib Graphs, where each graph is for a
         distinct Instance.
         """
-        return self._extract_subgraphs(BF.Instance)
+        return self._subgraphs(
+            "instances", lambda: self._extract_subgraphs(BF.Instance)
+        )
 
     def others(self) -> list[Graph]:
         """
         Return a list of "Other Resource" rdflib Graphs, where each graph is for a
         distinct resource.
         """
-        return self._extract_others()
+        return self._subgraphs("others", self._extract_others)
 
     def save(
-        self, session_maker: sessionmaker, max_attempts: int = SAVE_MAX_ATTEMPTS
+        self,
+        session_maker: sessionmaker,
+        max_attempts: int = SAVE_MAX_ATTEMPTS,
+        primary_class=None,
+        update_other_resources: bool = True,
     ) -> None:
         """
         Persists the graph to the database using the supplied sqlalchemy
@@ -178,6 +241,13 @@ class BluecoreGraph:
                 f"(attempt {retry_state.attempt_number} of {max_attempts})"
             )
 
+        # Strip the triples we never persist (see EXCLUDED_TRIPLE_TYPES) from the
+        # graph once, before minting extracts subgraphs. The per-entity subgraphs
+        # are then already clean, so _persist_resources can serialize the shared
+        # (cached) subgraph directly rather than copying each one just to strip
+        # these out. Idempotent, so re-running under a retry is a no-op.
+        self._strip_excluded_triples()
+
         try:
             for attempt in Retrying(
                 retry=retry_if_exception(_is_retryable_pg_error),
@@ -192,13 +262,27 @@ class BluecoreGraph:
                     self._mint_all_uris(BF.Work, session)
                     self._mint_all_uris(BF.Instance, session)
 
-                    # save resources from the graph to the database
-                    self._save(BF.Hub, session)
-                    self._save(BF.Work, session)
-                    self._save(BF.Instance, session)
-                    self._save(
-                        None, session
-                    )  # there is no catchall URI for Other Resources
+                    # save resources from the graph to the database. Only the
+                    # primary_class is authoritatively upserted; other kinds are
+                    # references (create-if-absent, never overwrite).
+                    # See _persist_resources.
+                    # primary_class is None means every kind is authoritative.
+                    def is_primary(kind) -> bool:
+                        return primary_class is None or primary_class == kind
+
+                    self._persist_resources(BF.Hub, session, is_primary(BF.Hub))
+                    self._persist_resources(BF.Work, session, is_primary(BF.Work))
+                    self._persist_resources(
+                        BF.Instance, session, is_primary(BF.Instance)
+                    )
+                    # Other Resources have no catchall URI (class_ is None) and
+                    # are the OtherResource kind for the primary check. On the
+                    # bulk path (primary_class None), update_other_resources can
+                    # opt out of re-describing already-present ones.
+                    other_is_primary = primary_class == OtherResource or (
+                        primary_class is None and update_other_resources
+                    )
+                    self._persist_resources(None, session, other_is_primary)
 
                     # flush so the just-added resources have ids and are
                     # visible to _link's uri lookups. Required because the
@@ -208,8 +292,19 @@ class BluecoreGraph:
                     # link rows with null foreign keys.
                     session.flush()
 
-                    # link all the works, instances and other resources together in the db
-                    self._link(session)
+                    # link all the works, instances and other resources together in the db.
+                    # _link issues many per-uri lookups; with autoflush on, each one
+                    # re-flushes the pending link changes (and re-fires update events /
+                    # bf-class recomputation). The resources it reads were already
+                    # flushed above, so turn autoflush off for the link phase and let
+                    # commit() do the single final flush. (bluecore_api's session already
+                    # runs with autoflush disabled.)
+                    prev_autoflush = session.autoflush
+                    session.autoflush = False
+                    try:
+                        self._link(session)
+                    finally:
+                        session.autoflush = prev_autoflush
 
                     # all changes are part of one transaction!
                     session.commit()
@@ -221,6 +316,7 @@ class BluecoreGraph:
         """
         Infer some triples that we rely on, and which may be missing.
         """
+        self._bump_revision()  # mutates self.graph
 
         # create inverse properties
         inverse_properties = [
@@ -517,6 +613,7 @@ class BluecoreGraph:
         A bibframe:derivedFrom assertion is added to record the relationship
         if the derived_from is URIRef.
         """
+        self._bump_revision()  # replace_uri + _generate_admin_metadata mutate self.graph
         replace_uri(self.graph, derived_from, bluecore_uri)
         # only add derivedFrom assertions for URIs
         if isinstance(derived_from, URIRef):
@@ -538,10 +635,31 @@ class BluecoreGraph:
     def _is_bluecore_uri(self, uri) -> bool:
         return uri in self.namespace
 
-    def _save(self, class_: URIRef | None, session: Session) -> None:
+    def _strip_excluded_triples(self) -> None:
+        """
+        Remove the triples we never persist (see EXCLUDED_TRIPLE_TYPES) from
+        self.graph. Called once from save() before subgraphs are extracted, so the
+        cached per-entity subgraphs -- and the JSON-LD serialized from them in
+        _persist_resources -- never contain these triples, and _persist_resources
+        can serialize the shared subgraphs without copying them first.
+        """
+        self._bump_revision()  # mutates self.graph
+        for predicate, type_ in EXCLUDED_TRIPLE_TYPES:
+            self._remove_triples_by_type(self.graph, predicate, type_)
+
+    def _persist_resources(
+        self, class_: URIRef | None, session: Session, is_primary: bool = True
+    ) -> None:
         """
         Persist resources of the supplied type to the given database session. If
         the type is None then Other Resources are saved.
+
+        When is_primary is True these resources are authoritatively upserted;
+        otherwise they are references, which we create if absent but never
+        overwrite -- so a reference (even one carrying a display label) can't
+        clobber an existing full description. (save() sets is_primary per kind
+        from its primary_class argument; None there means every kind is primary,
+        the original behavior.)
         """
         match class_:
             case BF.Hub:
@@ -563,13 +681,34 @@ class BluecoreGraph:
         if class_ is None:
             resources = sorted(resources, key=lambda g: str(self._subject(g, class_)))
 
-        for g in resources:
-            uri = self._subject(g, class_)
-            for predicate, type_ in EXCLUDED_TRIPLE_TYPES:
-                self._remove_triples_by_type(g, predicate, type_)
-            data = json.loads(g.serialize(format="json-ld"))
+        # Fetch the resources of this batch that already exist in a single query,
+        # keyed by uri, rather than a SELECT per resource -- so re-saves and large
+        # batches don't fan out into a round-trip each.
+        subjects = [self._subject(g, class_) for g in resources]
+        existing = {
+            obj.uri: obj
+            for obj in session.query(sqla_class).where(
+                sqla_class.uri.in_([str(uri) for uri in subjects])
+            )
+        }
 
-            obj = session.query(sqla_class).where(sqla_class.uri == uri).first()
+        for g, uri in zip(resources, subjects):
+            obj = existing.get(str(uri))
+
+            if obj is not None and not is_primary:
+                # a reference to an existing resource: link it (later, in _link)
+                # but never overwrite its stored description. Skip before building
+                # its JSON-LD -- serializing and re-framing it would be wasted work
+                # (this is the hot path when batch-loading records that share many
+                # Other Resources).
+                logger.info(f"keeping existing {uri} (referenced, not primary)")
+                continue
+
+            # Serialize the shared (cached) subgraph directly. save() already
+            # stripped EXCLUDED_TRIPLE_TYPES from self.graph up front (see
+            # _strip_excluded_triples), so there's nothing to remove here and no
+            # need to copy the subgraph to protect it from an in-place mutation.
+            data = json.loads(g.serialize(format="json-ld"))
 
             if obj:
                 obj.data = data
@@ -583,6 +722,10 @@ class BluecoreGraph:
                 else:
                     uuid = str(uri).split("/")[-1]
 
+                # create-if-absent for both primary and referenced resources; the
+                # stored data is the full extracted subgraph (whatever the payload
+                # knows -- inline triples + inferred type/link), so a referenced
+                # resource is created with a label etc. if it isn't in the db yet.
                 obj = sqla_class(uri=str(uri), uuid=uuid, data=data)
                 logger.info(f"inserting {uri}")
                 session.add(obj)
@@ -592,13 +735,21 @@ class BluecoreGraph:
         Save relations between Instances, Works and Other Resources in the graph.
         """
 
+        # Cache resource lookups for the duration of this link operation. _link
+        # resolves the same Works, Instances and Other Resources repeatedly (a
+        # Work is re-queried for every Other Resource it links to, etc.); caching
+        # by (type, uri) turns those repeats into a single query each. Every
+        # resource was flushed by save() before _link runs, so the first lookup
+        # already sees it.
+        cache: dict[tuple, object] = {}
+
         # use bibframe:instanceOf assertions to link instances with works
         #
         # Maybe we should have a simple inference step early on that infers missing
         # bibframe:instanceOf assertions, and possible other inverse properties
         # that we might rely on?
 
-        # sort all the link iterations by URI so that, like _save, concurrent
+        # sort all the link iterations by URI so that, like _persist_resources, concurrent
         # transactions acquire row locks in the same deterministic order.
 
         for s, o in sorted(
@@ -606,8 +757,8 @@ class BluecoreGraph:
             key=lambda pair: (str(pair[0]), str(pair[1])),
         ):
             logger.info(f"linking {s} to {o}")
-            instance = self._get_first(session, Instance, s)
-            work = self._get_first(session, Work, o)
+            instance = self._get_first(session, Instance, s, cache)
+            work = self._get_first(session, Work, o, cache)
             instance.work = work
             session.add(instance)
 
@@ -617,8 +768,8 @@ class BluecoreGraph:
             key=lambda pair: (str(pair[0]), str(pair[1])),
         ):
             logger.info(f"linking {s} to {o}")
-            work = self._get_first(session, Work, s)
-            instance = self._get_first(session, Instance, o)
+            work = self._get_first(session, Work, s, cache)
+            instance = self._get_first(session, Instance, o, cache)
             instance.work = work
             session.add(instance)
 
@@ -628,8 +779,8 @@ class BluecoreGraph:
 
         # first remove any existing Other Resource linkages between Works and
         # Instances so that they can be replaced with the new ones
-        self._delete_other_links(BF.Work, session)
-        self._delete_other_links(BF.Instance, session)
+        self._delete_other_links(BF.Work, session, cache)
+        self._delete_other_links(BF.Instance, session, cache)
 
         work_graphs = sorted(self.works(), key=lambda g: str(self._subject(g, BF.Work)))
         instance_graphs = sorted(
@@ -646,11 +797,9 @@ class BluecoreGraph:
                 if other_uri in g.objects():
                     work_uri = self._subject(g, BF.Work)
                     logger.info(f"linking {work_uri} to {other_uri}")
-                    work_model = session.query(Work).where(Work.uri == work_uri).first()
-                    other_model = (
-                        session.query(OtherResource)
-                        .where(OtherResource.uri == other_uri)
-                        .first()
+                    work_model = self._resolve(session, Work, work_uri, cache)
+                    other_model = self._resolve(
+                        session, OtherResource, other_uri, cache
                     )
                     session.add(
                         BibframeOtherResources(
@@ -665,15 +814,11 @@ class BluecoreGraph:
                 if other_uri in g.objects():
                     instance_uri = self._subject(g, BF.Instance)
                     logger.info(f"linking {instance_uri} to {other_uri}")
-                    instance_model = (
-                        session.query(Instance)
-                        .where(Instance.uri == instance_uri)
-                        .first()
+                    instance_model = self._resolve(
+                        session, Instance, instance_uri, cache
                     )
-                    other_model = (
-                        session.query(OtherResource)
-                        .where(OtherResource.uri == other_uri)
-                        .first()
+                    other_model = self._resolve(
+                        session, OtherResource, other_uri, cache
                     )
                     session.add(
                         BibframeOtherResources(
@@ -681,7 +826,9 @@ class BluecoreGraph:
                         )
                     )
 
-    def _delete_other_links(self, class_: URIRef, session: Session) -> None:
+    def _delete_other_links(
+        self, class_: URIRef, session: Session, cache: dict
+    ) -> None:
         """
         Delete existing links to OtherResources so that they can be replaced
         with new ones.
@@ -696,20 +843,33 @@ class BluecoreGraph:
 
         for g in graphs:
             uri = self._subject(g, class_)
-            bf_resource = (
-                session.query(sqla_class).where(sqla_class.uri == str(uri)).first()
-            )
+            bf_resource = self._resolve(session, sqla_class, uri, cache)
 
             session.query(BibframeOtherResources).filter(
                 BibframeOtherResources.bibframe_resource == bf_resource
             ).delete()
 
-    def _get_first(self, session: Session, sqla_class: Instance | Work, uri: Node):
+    def _resolve(self, session: Session, sqla_class, uri: Node, cache: dict):
+        """
+        Look up a resource of the given type by uri, caching the result (keyed by
+        type + uri) so repeated lookups within a single _link operation only hit
+        the database once. Returns None if there is no matching resource.
+        """
+        key = (sqla_class, str(uri))
+        if key not in cache:
+            cache[key] = (
+                session.query(sqla_class).where(sqla_class.uri == str(uri)).first()
+            )
+        return cache[key]
+
+    def _get_first(
+        self, session: Session, sqla_class: Instance | Work, uri: Node, cache: dict
+    ):
         """
         Look up the first object of the given type in the database and return it
         or throw an exception.
         """
-        obj = session.query(sqla_class).where(sqla_class.uri == uri).first()
+        obj = self._resolve(session, sqla_class, uri, cache)
         if obj is None:
             raise BluecoreGraphError(f"Unable to find in db: uri={uri}")
 

--- a/tests/test_bluecore_graph.py
+++ b/tests/test_bluecore_graph.py
@@ -2,7 +2,7 @@ import json
 import uuid
 
 import pytest
-from rdflib import BNode, Graph, Literal, URIRef
+from rdflib import BNode, Graph, Literal, RDFS, URIRef
 from sqlalchemy.orm import sessionmaker
 
 from bluecore_models import bluecore_graph
@@ -1061,3 +1061,259 @@ def _remove_fixtures(pg_session):
         session.query(BibframeOtherResources).delete()
         session.query(OtherResource).delete()
         session.commit()
+
+
+# ---------------------------------------------------------------------------
+# primary_class: references must not clobber existing full descriptions
+# ---------------------------------------------------------------------------
+
+
+def _new_uri(kind: str) -> str:
+    return f"https://bcld.info/{kind}/{uuid.uuid4()}"
+
+
+def test_reference_does_not_clobber_existing_instance(pg_session):
+    """
+    A Work saved as the primary that only *references* an existing Instance (even
+    with a display label) must leave the Instance's full description untouched,
+    and still create the link.
+    """
+    inst_uri = _new_uri("instances")
+    save_graph(
+        pg_session,
+        load_jsonld(
+            {
+                "@id": inst_uri,
+                "@type": BF.Instance,
+                "title": {"mainTitle": "Full Instance", "@type": "Title"},
+            }
+        ),
+    )
+    with pg_session() as session:
+        inst = session.query(Instance).where(Instance.uri == inst_uri).first()
+        before = json.dumps(inst.data, sort_keys=True)
+
+    work_uri = _new_uri("works")
+    g = Graph()
+    g.add((URIRef(work_uri), RDF.type, BF.Work))
+    g.add((URIRef(work_uri), BF.hasInstance, URIRef(inst_uri)))
+    g.add((URIRef(inst_uri), RDFS.label, Literal("display label")))
+    save_graph(pg_session, g, primary_class=BF.Work)
+
+    with pg_session() as session:
+        inst = session.query(Instance).where(Instance.uri == inst_uri).first()
+        # full description preserved -- the sparse reference did not overwrite it
+        assert inst.data["title"]["mainTitle"] == "Full Instance"
+        assert json.dumps(inst.data, sort_keys=True) == before
+        # link was still created
+        work = session.query(Work).where(Work.uri == work_uri).first()
+        assert work is not None
+        assert inst.work_id == work.id
+
+
+def test_reference_does_not_clobber_existing_work(pg_session):
+    """
+    Symmetric case: a new Instance saved as the primary that references an existing
+    Work (with only a label) must not overwrite the Work's full description.
+    """
+    work_uri = _new_uri("works")
+    save_graph(
+        pg_session,
+        load_jsonld(
+            {
+                "@id": work_uri,
+                "@type": BF.Work,
+                "title": {"mainTitle": "Full Work", "@type": "Title"},
+            }
+        ),
+    )
+    with pg_session() as session:
+        work = session.query(Work).where(Work.uri == work_uri).first()
+        before = json.dumps(work.data, sort_keys=True)
+
+    inst_uri = _new_uri("instances")
+    g = Graph()
+    g.add((URIRef(inst_uri), RDF.type, BF.Instance))
+    g.add((URIRef(inst_uri), BF.instanceOf, URIRef(work_uri)))
+    g.add((URIRef(work_uri), RDFS.label, Literal("display label")))
+    save_graph(pg_session, g, primary_class=BF.Instance)
+
+    with pg_session() as session:
+        work = session.query(Work).where(Work.uri == work_uri).first()
+        assert work.data["title"]["mainTitle"] == "Full Work"
+        assert json.dumps(work.data, sort_keys=True) == before
+        inst = session.query(Instance).where(Instance.uri == inst_uri).first()
+        assert inst is not None
+        assert inst.work_id == work.id
+
+
+def test_reference_to_absent_resource_is_created_with_known_triples(pg_session):
+    """
+    A reference to a resource that isn't in the db yet is created (so the link can
+    be made) storing whatever the payload knows about it -- not just the id.
+    """
+    work_uri = _new_uri("works")
+    inst_uri = _new_uri("instances")  # not yet in the db
+    g = Graph()
+    g.add((URIRef(work_uri), RDF.type, BF.Work))
+    g.add((URIRef(work_uri), BF.hasInstance, URIRef(inst_uri)))
+    g.add((URIRef(inst_uri), RDFS.label, Literal("just a label")))
+    save_graph(pg_session, g, primary_class=BF.Work)
+
+    with pg_session() as session:
+        inst = session.query(Instance).where(Instance.uri == inst_uri).first()
+        assert inst is not None  # created
+        assert "just a label" in json.dumps(inst.data)  # known triples captured
+        work = session.query(Work).where(Work.uri == work_uri).first()
+        assert inst.work_id == work.id  # linked
+
+
+def test_reference_does_not_clobber_existing_other_resource(pg_session):
+    """
+    Other Resources are shared and variably-described: a Work that references one
+    with only a label must not shrink an existing fuller description.
+    """
+    agent_uri = _new_uri("other_resources")
+    # a first Work creates the Agent with a fuller description (create-if-absent)
+    g1 = Graph()
+    w1 = _new_uri("works")
+    g1.add((URIRef(w1), RDF.type, BF.Work))
+    g1.add((URIRef(w1), BF.contribution, URIRef(agent_uri)))
+    g1.add((URIRef(agent_uri), RDF.type, BF.Agent))
+    g1.add((URIRef(agent_uri), RDFS.label, Literal("Ursula K. Le Guin")))
+    g1.add((URIRef(agent_uri), BF.note, Literal("author")))
+    save_graph(pg_session, g1, primary_class=BF.Work)
+    with pg_session() as session:
+        agent = (
+            session.query(OtherResource).where(OtherResource.uri == agent_uri).first()
+        )
+        assert agent is not None
+        before = json.dumps(agent.data, sort_keys=True)
+
+    # a second Work references the same Agent with only a sparse label
+    g2 = Graph()
+    w2 = _new_uri("works")
+    g2.add((URIRef(w2), RDF.type, BF.Work))
+    g2.add((URIRef(w2), BF.contribution, URIRef(agent_uri)))
+    g2.add((URIRef(agent_uri), RDF.type, BF.Agent))
+    g2.add((URIRef(agent_uri), RDFS.label, Literal("Le Guin")))
+    save_graph(pg_session, g2, primary_class=BF.Work)
+
+    with pg_session() as session:
+        agent = (
+            session.query(OtherResource).where(OtherResource.uri == agent_uri).first()
+        )
+        assert json.dumps(agent.data, sort_keys=True) == before  # unchanged
+
+
+def test_other_resource_as_primary_updates(pg_session):
+    """
+    With primary_class=OtherResource, the Other Resource is authoritative and IS
+    updated, while a Work it references stays create-if-absent.
+    """
+    agent_uri = _new_uri("other_resources")
+    w = _new_uri("works")
+    g1 = Graph()
+    g1.add((URIRef(w), RDF.type, BF.Work))
+    g1.add((URIRef(w), BF.contribution, URIRef(agent_uri)))
+    g1.add((URIRef(agent_uri), RDF.type, BF.Agent))
+    g1.add((URIRef(agent_uri), RDFS.label, Literal("Old Name")))
+    save_graph(pg_session, g1, primary_class=BF.Work)
+
+    g2 = Graph()
+    g2.add((URIRef(w), RDF.type, BF.Work))
+    g2.add((URIRef(w), BF.contribution, URIRef(agent_uri)))
+    g2.add((URIRef(agent_uri), RDF.type, BF.Agent))
+    g2.add((URIRef(agent_uri), RDFS.label, Literal("New Name")))
+    save_graph(pg_session, g2, primary_class=OtherResource)
+
+    with pg_session() as session:
+        agent = (
+            session.query(OtherResource).where(OtherResource.uri == agent_uri).first()
+        )
+        assert "New Name" in json.dumps(agent.data)  # authoritatively updated
+
+
+def test_primary_class_none_still_overwrites(pg_session):
+    """
+    The bulk-loader path (no primary_class) keeps the original upsert behavior:
+    every subject is authoritative and is overwritten.
+    """
+    inst_uri = _new_uri("instances")
+    save_graph(
+        pg_session,
+        load_jsonld(
+            {
+                "@id": inst_uri,
+                "@type": BF.Instance,
+                "title": {"mainTitle": "First", "@type": "Title"},
+            }
+        ),
+    )
+    save_graph(
+        pg_session,
+        load_jsonld(
+            {
+                "@id": inst_uri,
+                "@type": BF.Instance,
+                "title": {"mainTitle": "Second", "@type": "Title"},
+            }
+        ),
+    )
+    with pg_session() as session:
+        inst = session.query(Instance).where(Instance.uri == inst_uri).first()
+        assert inst.data["title"]["mainTitle"] == "Second"
+
+
+def test_update_other_resources_flag(pg_session):
+    """
+    On the bulk path (primary_class=None), update_other_resources=False treats
+    Other Resources as references (create-if-absent, never overwrite) so batch
+    loads don't needlessly re-describe shared Other Resources; the default True
+    still updates them.
+    """
+    agent_uri = _new_uri("other_resources")
+
+    def save_work_with_agent(label: str, **kwargs):
+        g = Graph()
+        w = _new_uri("works")
+        g.add((URIRef(w), RDF.type, BF.Work))
+        g.add((URIRef(w), BF.contribution, URIRef(agent_uri)))
+        g.add((URIRef(agent_uri), RDF.type, BF.Agent))
+        g.add((URIRef(agent_uri), RDFS.label, Literal(label)))
+        save_graph(pg_session, g, **kwargs)
+        return w
+
+    save_work_with_agent("Original")
+    with pg_session() as session:
+        before = json.dumps(
+            session.query(OtherResource)
+            .where(OtherResource.uri == agent_uri)
+            .first()
+            .data,
+            sort_keys=True,
+        )
+
+    # bulk save with update_other_resources=False must not re-describe the Agent
+    w2 = save_work_with_agent("Changed", update_other_resources=False)
+    with pg_session() as session:
+        agent = (
+            session.query(OtherResource).where(OtherResource.uri == agent_uri).first()
+        )
+        assert json.dumps(agent.data, sort_keys=True) == before  # unchanged
+        # but the new Work is still linked to the existing Agent
+        work2 = session.query(Work).where(Work.uri == w2).first()
+        link = (
+            session.query(BibframeOtherResources)
+            .where(BibframeOtherResources.bibframe_resource_id == work2.id)
+            .first()
+        )
+        assert link is not None and link.other_resource.uri == agent_uri
+
+    # default (update_other_resources=True) still updates the Agent
+    save_work_with_agent("Updated")
+    with pg_session() as session:
+        agent = (
+            session.query(OtherResource).where(OtherResource.uri == agent_uri).first()
+        )
+        assert "Updated" in json.dumps(agent.data)

--- a/tests/test_bluecore_graph.py
+++ b/tests/test_bluecore_graph.py
@@ -2,7 +2,7 @@ import json
 import uuid
 
 import pytest
-from rdflib import BNode, Graph, Literal, RDFS, URIRef
+from rdflib import RDFS, BNode, Graph, Literal, URIRef
 from sqlalchemy.orm import sessionmaker
 
 from bluecore_models import bluecore_graph


### PR DESCRIPTION
Closes #133 

## Summary

Speeds up `save_graph` (~2.2x on a real Airflow batch load) and fixes how
single-entity edits and batch loads interact with shared/referenced resources.

I loaded our `sample/batch.jsonld` from bluecore_api using `scripts/dev/load-data`. Before these changes it took 01:47 and after it took 00:48 seconds.

The performance wins from preventing unnecessary Other Resource updates should accelerate during a batch load, as more and more of the Other Resources will already be present in the database, and just require linking to rather than inserts.

Before:
<img width="1538" height="1050" alt="Screenshot 2026-07-22 at 8 57 24 PM" src="https://github.com/user-attachments/assets/c2e27ffb-8b56-4c08-896a-f5194cd954ee" />

After:
<img width="1538" height="1050" alt="Screenshot 2026-07-23 at 2 31 28 PM" src="https://github.com/user-attachments/assets/7fa878be-83c9-4000-aa15-b729b3dc4159" />

Originally this work was two stacked PRs (#137 perf + this one); folded into one since the perf work and the reference handling are now entangled and reviewers don't need them split.

## 1. Performance (~2.2x on a real Airflow batch load)

- **Memoize entity subgraph extraction**, invalidated by a graph revision counter,
  so the repeated `works()`/`instances()`/`hubs()`/`others()` calls across a save
  don't re-extract each time.
- **Batch existence lookups** into one query per resource type instead of a
  SELECT per resource.
- **Cache resource lookups within `_link`** to avoid repeat queries.
- **Disable autoflush during `_link`** to avoid a per-lookup flush storm (the
  resources it reads are already flushed).
- **Strip excluded triples once** up front in `save()` (`_strip_excluded_triples`)
  instead of copying each subgraph to strip them per-resource — removes `_copy_graph`
  and one full subgraph copy per primary resource.
- Adds a `save_graph` benchmark/profiler tool (documented in the README).

## 2. References must not clobber full descriptions (`primary_class`)

Posting/putting a single entity that **references** another (a Work with
`bf:hasInstance` an existing Instance, a new Instance with `bf:instanceOf` an
existing Work, or a Work carrying a partial Agent) parsed the whole payload and
upserted **every** typed subject, so the sparse reference overwrote the existing
full description (and wrote a partial Version). Both directions, POST and PUT, and
Other Resources.

A reference can carry a display label, so "reference vs full" can't be told from
content — the reliable signal is *intent*. Add optional **`primary_class`**
(`BF.Work`/`BF.Instance`/`BF.Hub`/the `OtherResource` class):
- primary kind → full upsert (unchanged),
- every other kind → **reference: create-if-absent, never overwrite** (a created
  reference stores whatever the payload knows, label and all),
- `primary_class=None` → all kinds authoritative → **existing behavior unchanged**.

## 3. Skip needless Other Resource re-writes in batch loads (`update_other_resources`)

Assigning `obj.data` re-runs the expensive JSON-LD framing even when unchanged, and
real CBD records carry many Other Resources (~26 each vs 1 work + 1 instance), so
the bulk path re-described shared Other Resources on every record. Add
**`update_other_resources`** (default `True`): when `False`, Other Resources are
references even with `primary_class=None`, so batch loading links them without
re-describing them (their descriptions maintained by a separate process). Also
skips the copy/serialize/frame for any reference we're going to skip.

## Tests

New tests cover both link directions, Other Resources, create-if-absent,
OtherResource-as-primary, `primary_class=None` still overwrites, and
`update_other_resources=False`. Full suite **75 tests** pass; no `save_graph`
benchmark regression from the `primary_class` work.

## Follow-ups (separate, gated on a bluecore-models release)

- `bluecore_api`: pass `primary_class` per route (Work/Instance/Hub).
- bluecore-workflows bulk loader: pass `update_other_resources=False`.
