### PR TITLE
Fix lint errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-models"
-version = "0.24.3"
+version = "0.25.0"
 description = "Blue Core BIBFRAME Data Models"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -4,21 +4,21 @@ import logging
 from uuid import uuid4
 
 from psycopg2 import errors as psycopg2_errors
-from rdflib import BNode, Graph, IdentifiedNode, Literal, Namespace, Node, URIRef, XSD
+from rdflib import XSD, BNode, Graph, IdentifiedNode, Literal, Namespace, Node, URIRef
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, OperationalError
-from sqlalchemy.orm.session import sessionmaker, Session
+from sqlalchemy.orm.session import Session, sessionmaker
 from tenacity import Retrying, retry_if_exception, stop_after_attempt
 
-from bluecore_models.namespaces import BF, BFLC, MADS, RDF
 from bluecore_models.models import (
-    Work,
-    Instance,
-    Hub,
-    OtherResource,
     BibframeOtherResources,
+    Hub,
+    Instance,
+    OtherResource,
+    Work,
 )
 from bluecore_models.models.version import CURRENT_USER_ID
+from bluecore_models.namespaces import BF, BFLC, MADS, RDF
 from bluecore_models.utils.graph import generate_entity_graph, replace_uri
 
 logger = logging.getLogger(__name__)

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -48,6 +48,7 @@ DEFAULT_DESC_LEVEL = URIRef("http://id.loc.gov/ontologies/bibframe-2-6-0/")
 class BluecoreGraphError(Exception):
     """Raised for BluecoreGraph errors that aren't a type mismatch."""
 
+
 # (predicate, rdf:type) pairs identifying blank nodes that are stripped out of
 # a resource's graph before it is persisted to the database, e.g. removing
 # OCLC number identifiers that shouldn't be exposed.
@@ -114,7 +115,9 @@ class BluecoreGraph:
         if not isinstance(namespace, str):
             raise TypeError(f"default namespace cannot be {namespace}")
         elif not namespace.startswith("http"):
-            raise BluecoreGraphError(f"default namespace must be a URL, got {namespace}")
+            raise BluecoreGraphError(
+                f"default namespace must be a URL, got {namespace}"
+            )
         elif not namespace.endswith("/"):
             namespace += "/"
         self.namespace = Namespace(namespace)

--- a/src/bluecore_models/bluecore_graph.py
+++ b/src/bluecore_models/bluecore_graph.py
@@ -37,6 +37,17 @@ RETRYABLE_PG_ERRORS = (
 # How many times to attempt save() before giving up on serialization failures.
 SAVE_MAX_ATTEMPTS = 3
 
+# Default AdminMetadata values used when a caller doesn't override them.
+DEFAULT_STATUS = URIRef("http://id.loc.gov/vocabulary/mstatus/c")
+DEFAULT_AGENT = URIRef("http://id.loc.gov/vocabulary/organizations/bcld")
+DEFAULT_DESC_AUTH = URIRef("http://id.loc.gov/vocabulary/marcauthen/pcc")
+DEFAULT_DESC_LANG = URIRef("http://id.loc.gov/vocabulary/languages/eng")
+DEFAULT_DESC_LEVEL = URIRef("http://id.loc.gov/ontologies/bibframe-2-6-0/")
+
+
+class BluecoreGraphError(Exception):
+    """Raised for BluecoreGraph errors that aren't a type mismatch."""
+
 # (predicate, rdf:type) pairs identifying blank nodes that are stripped out of
 # a resource's graph before it is persisted to the database, e.g. removing
 # OCLC number identifiers that shouldn't be exposed.
@@ -101,9 +112,9 @@ class BluecoreGraph:
         Bluecore Namespace URL: the default is https://bcld.info.
         """
         if not isinstance(namespace, str):
-            raise Exception(f"default namespace cannot be {namespace}")
+            raise TypeError(f"default namespace cannot be {namespace}")
         elif not namespace.startswith("http"):
-            raise Exception(f"default namespace must be a URL, got {namespace}")
+            raise BluecoreGraphError(f"default namespace must be a URL, got {namespace}")
         elif not namespace.endswith("/"):
             namespace += "/"
         self.namespace = Namespace(namespace)
@@ -171,35 +182,34 @@ class BluecoreGraph:
                 before_sleep=log_retry,
                 reraise=True,
             ):
-                with attempt:
-                    with session_maker() as session:
-                        # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
-                        # note: OtherResources keep their original URI
-                        self._mint_all_uris(BF.Hub, session)
-                        self._mint_all_uris(BF.Work, session)
-                        self._mint_all_uris(BF.Instance, session)
+                with attempt, session_maker() as session:
+                    # resolve URIs in the graph to their Bluecore equivalent or mint them as appropriate.
+                    # note: OtherResources keep their original URI
+                    self._mint_all_uris(BF.Hub, session)
+                    self._mint_all_uris(BF.Work, session)
+                    self._mint_all_uris(BF.Instance, session)
 
-                        # save resources from the graph to the database
-                        self._save(BF.Hub, session)
-                        self._save(BF.Work, session)
-                        self._save(BF.Instance, session)
-                        self._save(
-                            None, session
-                        )  # there is no catchall URI for Other Resources
+                    # save resources from the graph to the database
+                    self._save(BF.Hub, session)
+                    self._save(BF.Work, session)
+                    self._save(BF.Instance, session)
+                    self._save(
+                        None, session
+                    )  # there is no catchall URI for Other Resources
 
-                        # flush so the just-added resources have ids and are
-                        # visible to _link's uri lookups. Required because the
-                        # session may have autoflush disabled (as the
-                        # bluecore_api session does), in which case _link's
-                        # queries would otherwise not see them and would build
-                        # link rows with null foreign keys.
-                        session.flush()
+                    # flush so the just-added resources have ids and are
+                    # visible to _link's uri lookups. Required because the
+                    # session may have autoflush disabled (as the
+                    # bluecore_api session does), in which case _link's
+                    # queries would otherwise not see them and would build
+                    # link rows with null foreign keys.
+                    session.flush()
 
-                        # link all the works, instances and other resources together in the db
-                        self._link(session)
+                    # link all the works, instances and other resources together in the db
+                    self._link(session)
 
-                        # all changes are part of one transaction!
-                        session.commit()
+                    # all changes are part of one transaction!
+                    session.commit()
         except (OperationalError, IntegrityError) as error:
             logger.error(f"Exceeded {max_attempts} attempts with error {error}")
             raise
@@ -273,11 +283,11 @@ class BluecoreGraph:
         self,
         bluecore_uri: URIRef,
         source_uri: URIRef,
-        status: URIRef = URIRef("http://id.loc.gov/vocabulary/mstatus/c"),
-        agent: URIRef = URIRef("http://id.loc.gov/vocabulary/organizations/bcld"),
-        desc_auth: URIRef = URIRef("http://id.loc.gov/vocabulary/marcauthen/pcc"),
-        desc_lang: URIRef = URIRef("http://id.loc.gov/vocabulary/languages/eng"),
-        desc_level: URIRef = URIRef("http://id.loc.gov/ontologies/bibframe-2-6-0/"),
+        status: URIRef = DEFAULT_STATUS,
+        agent: URIRef = DEFAULT_AGENT,
+        desc_auth: URIRef = DEFAULT_DESC_AUTH,
+        desc_lang: URIRef = DEFAULT_DESC_LANG,
+        desc_level: URIRef = DEFAULT_DESC_LEVEL,
     ):
         """
         Generates two bf:AdminMetadata blank nodes for incoming RDF resources that are
@@ -378,20 +388,22 @@ class BluecoreGraph:
             # OtherResource graph, which assumes there is one subject URI and ignores BNodes.
             uris = list(set(filter(lambda s: isinstance(s, URIRef), graph.subjects())))
         else:
-            raise Exception("Unexpected class_ type, must be URIRef or None")
+            raise BluecoreGraphError("Unexpected class_ type, must be URIRef or None")
 
         # there should only be one subject
         if len(uris) == 0:
-            raise Exception(f"Unable to find subject URI for {class_}")
+            raise BluecoreGraphError(f"Unable to find subject URI for {class_}")
         elif len(uris) != 1:
             # try removing any bnodes when more than one subject was found
             uris = list(filter(lambda s: isinstance(s, URIRef), uris))
             if len(uris) != 1:
-                raise Exception(f"Found more than one subject URI for {class_}: {uris}")
+                raise BluecoreGraphError(
+                    f"Found more than one subject URI for {class_}: {uris}"
+                )
 
         # ensure we've got a BNode or URIRef
         if not isinstance(uris[0], IdentifiedNode):
-            raise Exception(f"Found unexpected subject identifier: {uris[0]}")
+            raise TypeError(f"Found unexpected subject identifier: {uris[0]}")
 
         return uris[0]
 
@@ -412,7 +424,7 @@ class BluecoreGraph:
                 subgraphs = self.instances()
                 sqla_class = Instance
             case _:
-                raise Exception("Can't mint URIs for class of type {class_}")
+                raise BluecoreGraphError(f"Can't mint URIs for class of type {class_}")
 
         for sg in subgraphs:
             uri = self._subject(sg, class_)
@@ -472,7 +484,9 @@ class BluecoreGraph:
             case BF.Instance:
                 type_of = "instances"
             case _:
-                raise Exception("Can't mint Bluecore URI for class of type {class_}")
+                raise BluecoreGraphError(
+                    f"Can't mint Bluecore URI for class of type {class_}"
+                )
 
         return self.namespace[f"{type_of}/{uuid}"]
 
@@ -694,6 +708,6 @@ class BluecoreGraph:
         """
         obj = session.query(sqla_class).where(sqla_class.uri == uri).first()
         if obj is None:
-            raise Exception(f"Unable to find in db: uri={uri}")
+            raise BluecoreGraphError(f"Unable to find in db: uri={uri}")
 
         return obj

--- a/src/bluecore_models/migrations/env.py
+++ b/src/bluecore_models/migrations/env.py
@@ -1,30 +1,27 @@
 import os
 import pathlib
 import sys
-
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 current_dir = pathlib.Path(".")
 src = current_dir.parent / "src"
 
 sys.path = ["", str(src.absolute())] + sys.path[1:]
 
-from bluecore_models.models import (  # noqa: E402
+from bluecore_models.models import (
     Base,
-    ResourceBase,  # noqa: F401
+    BibframeClass,  # noqa: F401
+    BibframeOtherResources,  # noqa: F401
     Hub,  # noqa: F401
     Instance,  # noqa: F401
-    Work,  # noqa: F401
-    BibframeClass,  # noqa: F401
+    OtherResource,  # noqa: F401
+    ResourceBase,  # noqa: F401
     ResourceBibframeClass,  # noqa: F401
     Version,  # noqa: F401
-    OtherResource,  # noqa: F401
-    BibframeOtherResources,  # noqa: F401
+    Work,  # noqa: F401
 )
 
 # this is the Alembic Config object, which provides

--- a/src/bluecore_models/migrations/versions/20260626_add_profiles_table.py
+++ b/src/bluecore_models/migrations/versions/20260626_add_profiles_table.py
@@ -13,8 +13,8 @@ Create Date: 2026-06-26
 
 import os
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260626"

--- a/src/bluecore_models/migrations/versions/37f5d0142d42_remove_updated_at_from_version_model.py
+++ b/src/bluecore_models/migrations/versions/37f5d0142d42_remove_updated_at_from_version_model.py
@@ -6,17 +6,17 @@ Create Date: 2025-04-17 16:47:42.968851
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "37f5d0142d42"
-down_revision: Union[str, None] = "b53d03c9abf2"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "b53d03c9abf2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/3be9942c0ebe_new_uuid_field.py
+++ b/src/bluecore_models/migrations/versions/3be9942c0ebe_new_uuid_field.py
@@ -6,17 +6,17 @@ Create Date: 2025-05-07 16:56:51.814192
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "3be9942c0ebe"
-down_revision: Union[str, None] = "37f5d0142d42"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "37f5d0142d42"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/58d1931e61fe_new_composite_index_using_bf_type_and_.py
+++ b/src/bluecore_models/migrations/versions/58d1931e61fe_new_composite_index_using_bf_type_and_.py
@@ -6,17 +6,16 @@ Create Date: 2026-06-30 15:01:35.291005
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "58d1931e61fe"
-down_revision: Union[str, None] = "20260626"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "20260626"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/90f448095118_data_vector.py
+++ b/src/bluecore_models/migrations/versions/90f448095118_data_vector.py
@@ -6,17 +6,17 @@ Create Date: 2025-07-27 18:34:28.913385
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "90f448095118"
-down_revision: Union[str, None] = "3be9942c0ebe"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "3be9942c0ebe"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/911a986691ba_resources_and_other_resources_index.py
+++ b/src/bluecore_models/migrations/versions/911a986691ba_resources_and_other_resources_index.py
@@ -6,15 +6,15 @@ Create Date: 2026-07-01 14:01:07.144023
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "911a986691ba"
-down_revision: Union[str, None] = "20260701"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "20260701"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/a2d0be58df6c_adds_bibframe_hubs.py
+++ b/src/bluecore_models/migrations/versions/a2d0be58df6c_adds_bibframe_hubs.py
@@ -6,17 +6,16 @@ Create Date: 2026-06-16 14:44:35.656040
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a2d0be58df6c"
-down_revision: Union[str, None] = "66a2614cbe62"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "66a2614cbe62"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/ad784bf46c6f_create_type_index.py
+++ b/src/bluecore_models/migrations/versions/ad784bf46c6f_create_type_index.py
@@ -6,16 +6,15 @@ Create Date: 2025-08-01 10:30:52.579736
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "ad784bf46c6f"
-down_revision: Union[str, None] = "20250728"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "20250728"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/b53d03c9abf2_initial_data_models.py
+++ b/src/bluecore_models/migrations/versions/b53d03c9abf2_initial_data_models.py
@@ -6,17 +6,17 @@ Create Date: 2025-02-14 09:46:22.075751
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "b53d03c9abf2"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/da65046e4024_add_keycloak_user_id_to_versions.py
+++ b/src/bluecore_models/migrations/versions/da65046e4024_add_keycloak_user_id_to_versions.py
@@ -5,15 +5,15 @@ Revises: ad784bf46c6f
 Create Date: 2025-09-29 07:43:07.109100
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision: str = "da65046e4024"
-down_revision: Union[str, None] = "ad784bf46c6f"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "ad784bf46c6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/migrations/versions/fe63e3fe2d6f_search_improvements.py
+++ b/src/bluecore_models/migrations/versions/fe63e3fe2d6f_search_improvements.py
@@ -6,19 +6,19 @@ Create Date: 2026-04-20 15:06:39.889064
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 from bluecore_models.models.pg_ext_func import PG_EXT_FUNC
 
 # revision identifiers, used by Alembic.
 revision: str = "66a2614cbe62"
-down_revision: Union[str, None] = "da65046e4024"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "da65046e4024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/bluecore_models/models/__init__.py
+++ b/src/bluecore_models/models/__init__.py
@@ -1,15 +1,19 @@
 from bluecore_models.models.base import Base as Base
-from bluecore_models.models.resource import ResourceBase as ResourceBase
 from bluecore_models.models.bf_classes import (
     BibframeClass as BibframeClass,
+)
+from bluecore_models.models.bf_classes import (
     ResourceBibframeClass as ResourceBibframeClass,
 )
 from bluecore_models.models.hub import Hub as Hub
 from bluecore_models.models.instance import Instance as Instance
-from bluecore_models.models.version import Version as Version
-from bluecore_models.models.work import Work as Work
 from bluecore_models.models.other_resource import (
-    OtherResource as OtherResource,
     BibframeOtherResources as BibframeOtherResources,
 )
+from bluecore_models.models.other_resource import (
+    OtherResource as OtherResource,
+)
 from bluecore_models.models.profile import Profile as Profile
+from bluecore_models.models.resource import ResourceBase as ResourceBase
+from bluecore_models.models.version import Version as Version
+from bluecore_models.models.work import Work as Work

--- a/src/bluecore_models/models/bf_classes.py
+++ b/src/bluecore_models/models/bf_classes.py
@@ -1,18 +1,17 @@
 from datetime import datetime
 
-
 from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
     String,
 )
-
 from sqlalchemy.orm import (
-    mapped_column,
     Mapped,
+    mapped_column,
     relationship,
 )
+
 from bluecore_models.models.base import Base
 from bluecore_models.models.resource import ResourceBase
 

--- a/src/bluecore_models/models/hub.py
+++ b/src/bluecore_models/models/hub.py
@@ -1,6 +1,6 @@
 """Module for BIBFRAME Hubs"""
 
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import (
     Connection,
@@ -28,7 +28,7 @@ class Hub(ResourceBase):
         "Work", primaryjoin="Hub.id == Work.hub_id", back_populates="hub"
     )
 
-    __mapper_args__ = {
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_identity": "hubs",
     }
 

--- a/src/bluecore_models/models/instance.py
+++ b/src/bluecore_models/models/instance.py
@@ -1,6 +1,6 @@
 """Module for BIBFRAME Instances"""
 
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import (
     Connection,
@@ -32,7 +32,7 @@ class Instance(ResourceBase):
     work: Mapped["Work"] = relationship(  # type: ignore  # noqa: F821
         "Work", foreign_keys=work_id, back_populates="instances"
     )
-    __mapper_args__ = {
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_identity": "instances",
     }
 

--- a/src/bluecore_models/models/other_resource.py
+++ b/src/bluecore_models/models/other_resource.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import Connection, DateTime, ForeignKey, Index, Integer, event
 from sqlalchemy.orm import (
@@ -23,7 +23,7 @@ class OtherResource(ResourceBase):
         Integer, ForeignKey("resource_base.id"), primary_key=True
     )
 
-    __mapper_args__ = {
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_identity": "other_resources",
     }
 

--- a/src/bluecore_models/models/profile.py
+++ b/src/bluecore_models/models/profile.py
@@ -1,3 +1,5 @@
+from typing import Any, ClassVar
+
 from sqlalchemy import ForeignKey, Integer, event
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -21,7 +23,7 @@ class Profile(ResourceBase):
         Integer, ForeignKey("resource_base.id"), primary_key=True
     )
 
-    __mapper_args__ = {
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_identity": "profiles",
     }
 

--- a/src/bluecore_models/models/resource.py
+++ b/src/bluecore_models/models/resource.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import Computed, Connection, DateTime, Index, String, Uuid, event, text
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
@@ -52,7 +52,7 @@ class ResourceBase(Base):
         ),
     )
 
-    __mapper_args__ = {  # type: ignore
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_on": type,
         "polymorphic_identity": "resource_base",
     }

--- a/src/bluecore_models/models/work.py
+++ b/src/bluecore_models/models/work.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import (
     Connection,
@@ -35,7 +35,7 @@ class Work(ResourceBase):
         "Instance", primaryjoin="Work.id == Instance.work_id", back_populates="work"
     )
 
-    __mapper_args__ = {
+    __mapper_args__: ClassVar[dict[str, Any]] = {
         "polymorphic_identity": "works",
     }
 

--- a/src/bluecore_models/utils/db.py
+++ b/src/bluecore_models/utils/db.py
@@ -34,10 +34,7 @@ def add_version(connection, resource):
     """
     Adds a Version if the resource had been modified.
     """
-    try:
-        uid = CURRENT_USER_ID.get()
-    except Exception:
-        uid = None
+    uid = CURRENT_USER_ID.get()
 
     if object_session(resource).is_modified(resource, include_collections=False):
         stmt = insert(Version.__table__).values(
@@ -52,14 +49,14 @@ def add_version(connection, resource):
 def update_bf_classes(connection, resource):
     """Update Bibframe classes for a resource"""
     bf_classes = get_bf_classes(resource.data, resource.uri)
-    latest_bf_classes = set(str(bf_class) for bf_class in bf_classes)
+    latest_bf_classes = {str(bf_class) for bf_class in bf_classes}
     stmt = (
         select(BibframeClass.__table__.columns.uri)
         .where(BibframeClass.id == ResourceBibframeClass.bf_class_id)
         .where(ResourceBibframeClass.resource_id == resource.id)
     )
     result = connection.execute(stmt)
-    existing_bf_classes = set(bf_class_uri for bf_class_uri in result.scalars())
+    existing_bf_classes = set(result.scalars())
     removed_classes = existing_bf_classes - latest_bf_classes
     added_classes = latest_bf_classes - existing_bf_classes
     for bf_class in removed_classes:

--- a/src/bluecore_models/utils/graph.py
+++ b/src/bluecore_models/utils/graph.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from pyld import jsonld
-from rdflib import BNode, DCTERMS, Graph, IdentifiedNode, Node, RDF, URIRef
+from rdflib import DCTERMS, RDF, BNode, Graph, IdentifiedNode, Node, URIRef
 from rdflib.plugins import sparql
 
 from bluecore_models.namespaces import BF, BFLC, LCLOCAL, MADS

--- a/src/bluecore_models/utils/vector_db.py
+++ b/src/bluecore_models/utils/vector_db.py
@@ -78,8 +78,8 @@ def create_embeddings(
     resource_uri = version.resource.uri
     embeddings_data = generate_vectors(version_graph, resource_uri, version_id)
 
-    logging.info(
+    logger.info(
         f"Creating embeddings for {resource_uri} version {version_id}, total vectors: {len(embeddings_data)}"
     )
     result = client.insert(collection_name=collection, data=embeddings_data)
-    logging.info(f"Inserted {result['insert_count']} triple embeddings")
+    logger.info(f"Inserted {result['insert_count']} triple embeddings")

--- a/src/bluecore_models/utils/vector_db.py
+++ b/src/bluecore_models/utils/vector_db.py
@@ -2,13 +2,10 @@ import logging
 import os
 
 import rdflib
+from pymilvus import MilvusClient, model
 
-from typing import Union
-
-from pymilvus import model, MilvusClient
-
-from bluecore_models.utils.graph import load_jsonld
 from bluecore_models.models import Version
+from bluecore_models.utils.graph import load_jsonld
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +65,7 @@ def generate_vectors(graph: rdflib.Graph, resource_uri: str, version_id: int) ->
 
 
 def create_embeddings(
-    version: Version, collection: str, client: Union[MilvusClient, None] = None
+    version: Version, collection: str, client: MilvusClient | None = None
 ):
     if not client:
         client = MilvusClient(uri=MILVUS_URI)

--- a/tests/test_bluecore_graph.py
+++ b/tests/test_bluecore_graph.py
@@ -965,7 +965,8 @@ def test_hubs_are_not_other_resources(pg_session):
     being added to the database twice, which will cause a unique constraint
     violation.
     """
-    g = load_jsonld(json.load(open("tests/data/19167709.cbd.jsonld")))
+    with open("tests/data/19167709.cbd.jsonld") as fo:
+        g = load_jsonld(json.load(fo))
     save_graph(pg_session, g)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID, uuid1
 
-import pytest  # noqa
+import pytest
 import rdflib
 
 from bluecore_models.models import (
@@ -372,7 +372,8 @@ def test_hub_work_relationship(pg_session):
 
 
 def test_hub_jsonld_framing():
-    hub_json = json.load(Path("tests/data/blue-core-hub.jsonld").open())
+    with Path("tests/data/blue-core-hub.jsonld").open() as fo:
+        hub_json = json.load(fo)
     hub = Hub(
         uri="http://id.loc.gov/resources/hubs/62a26d82-4e65-c696-afed-b12d215a35b1",
         data=hub_json,
@@ -388,7 +389,8 @@ def test_hub_jsonld_framing():
 
 
 def test_work_jsonld_framing():
-    work_json = json.load(Path("tests/data/blue-core-work.jsonld").open())
+    with Path("tests/data/blue-core-work.jsonld").open() as fo:
+        work_json = json.load(fo)
     work = Work(
         uri="https://bluecore.info/works/23db8603-1932-4c3f-968c-ae584ef1b4bb",
         data=work_json,
@@ -410,7 +412,8 @@ def test_work_jsonld_framing():
 
 
 def test_instance_jsonld_framing():
-    instance_json = json.load(Path("tests/data/blue-core-instance.jsonld").open())
+    with Path("tests/data/blue-core-instance.jsonld").open() as fo:
+        instance_json = json.load(fo)
     instance = Instance(
         uri="https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
         data=instance_json,
@@ -528,13 +531,15 @@ def test_work_with_non_standard_namespaces(pg_session):
     Ensure that a Work with non-standard namespaces in its JSON-LD can be
     persisted and retrieved.
     """
+    with pathlib.Path("tests/data/foo_work.jsonld").open() as fo:
+        work_data = json.load(fo)
     with pg_session() as session:
         time_now = datetime.now(UTC)
         foo_work = Work(
             uri="https://bcld.info/works/1234",
             created_at=time_now,
             updated_at=time_now,
-            data=json.load(pathlib.Path("tests/data/foo_work.jsonld").open()),
+            data=work_data,
             uuid=UUID("bb5eb231-a968-425f-b74c-39f21977fa54"),
             type="works",
         )

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -7,10 +7,9 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from bluecore_models.bluecore_graph import BluecoreGraph, save_graph
-from bluecore_models.models import Instance, OtherResource, Work, BibframeOtherResources
+from bluecore_models.models import BibframeOtherResources, Instance, OtherResource, Work
 from bluecore_models.namespaces import BF
 from bluecore_models.utils.graph import load_jsonld
-
 
 jsonld_context = {
     "@vocab": "http://id.loc.gov/ontologies/bibframe/",

--- a/tests/test_save_graph_deadlocks.py
+++ b/tests/test_save_graph_deadlocks.py
@@ -168,7 +168,12 @@ def test_concurrent_first_time_create_of_same_uri(pg_session):
 
         barrier = threading.Barrier(writers)
 
-        def writer(idx: int, other_uri: str = other_uri) -> None:
+        def writer(
+            idx: int,
+            other_uri: str = other_uri,
+            round_num: int = round_num,
+            barrier: threading.Barrier = barrier,
+        ) -> None:
             work_uuid = f"{round_num:02d}{idx:02d}0000-0000-0000-0000-000000000000"
             graph = _work_referencing_shared_other(work_uuid, other_uri)
             barrier.wait()  # all writers do get-or-create before anyone commits
@@ -272,7 +277,7 @@ def test_concurrent_writers_sharing_authorities_no_deadlock(pg_session):
 
     for round_num in range(_NUM_ROUNDS):
 
-        def writer(idx: int) -> None:
+        def writer(idx: int, round_num: int = round_num) -> None:
             order = _SHARED_AUTHORITIES[:]
             random.Random(round_num * 1000 + idx).shuffle(order)
             work_uuid = f"{round_num:02d}{idx:02d}0000-0000-0000-0000-000000000000"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,17 +2,17 @@ import json
 from pathlib import Path
 
 import rdflib
-from rdflib import URIRef, Literal, DCTERMS
+from rdflib import DCTERMS, Literal, URIRef
 
 from bluecore_models.utils.graph import (
     BF,
     BFLC,
     MADS,
+    _expand_bnode,
     generate_entity_graph,
     init_graph,
     load_jsonld,
     replace_uri,
-    _expand_bnode,
 )
 
 
@@ -25,7 +25,8 @@ def test_init_graph():
 
 
 def test_load_jsonld():
-    graph = load_jsonld(json.load(Path("tests/data/23807141.jsonld").open()))
+    with Path("tests/data/23807141.jsonld").open() as fo:
+        graph = load_jsonld(json.load(fo))
     assert graph.namespace_manager.store.namespace("bf") == URIRef(BF)
     assert graph.namespace_manager.store.namespace("bflc") == URIRef(BFLC)
     assert graph.namespace_manager.store.namespace("mads") == URIRef(MADS)
@@ -33,7 +34,8 @@ def test_load_jsonld():
 
 
 def test_generate_entity_graph():
-    loc_graph = load_jsonld(json.load(Path("tests/data/23807141.jsonld").open()))
+    with Path("tests/data/23807141.jsonld").open() as fo:
+        loc_graph = load_jsonld(json.load(fo))
 
     work_uri = URIRef("http://id.loc.gov/resources/works/23807141")
     dcterm_part_of = loc_graph.value(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -217,8 +217,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -273,7 +273,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
     { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
     { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
     { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
     { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
     { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
     { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
@@ -281,7 +283,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/9a/e51225dcd58713f16ccbdcc501a8da21098ea14515b7870f1f94459e5ff5/greenlet-3.5.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:24e61b88cb7e1b1d794b32a10cc346ac779681d6d74ff137a3e0a444d2bf1f02", size = 294831, upload-time = "2026-07-22T11:38:53.389Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ea/de50a50fadf979713ab18b46f22ad5ff5f2dcfc637a3ebdecf669801e1a5/greenlet-3.5.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:870d730fec833f5a06906a32596cc099b9161594642a92a520b7a88911c95356", size = 614619, upload-time = "2026-07-22T12:26:42.282Z" },
     { url = "https://files.pythonhosted.org/packages/db/c7/2aae27fea41205b8650294c301f042a2a4bb6155eea48c995b890a92f2c1/greenlet-3.5.4-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec5ff0d1878df6af3bf9b638a5a92a7d5693291de77c91bff10fa48519c604ef", size = 627021, upload-time = "2026-07-22T12:29:03.445Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/fb4d4788bbc8e54761f1fc88533af9523a6e86299fa113d6e8a8503ed9fc/greenlet-3.5.4-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07bd44616608d873d06735b63ef1a88191d6ca57c8d291d6559c71bc14c0893c", size = 632845, upload-time = "2026-07-22T12:43:45.19Z" },
     { url = "https://files.pythonhosted.org/packages/eb/56/79fd826f9ccaae0b84e1b4ef68dabba5e105bb044ffcd448a0b782fcba9a/greenlet-3.5.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d84d993f6e575c950d91a23c1345d18fe1a4310d447bf630849d7809196b52f0", size = 624002, upload-time = "2026-07-22T11:51:11.391Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e3/6086fa578ebb72772722cdc4bcd628459814b42e0c2db1e3cbd6552b3271/greenlet-3.5.4-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:3529a8a933582ad19e224792cac7372489526576b75b4c124e8e4f29948f4861", size = 435053, upload-time = "2026-07-22T12:39:52.715Z" },
     { url = "https://files.pythonhosted.org/packages/0a/1a/27319f97e731298513dcba1a2e91b63e9d8811d9de22130f960b129b1bf1/greenlet-3.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:58023945f421093de5e6fa108c0985a8659d43f49e0216da25099369a121bcbd", size = 1581533, upload-time = "2026-07-22T12:25:05.322Z" },
     { url = "https://files.pythonhosted.org/packages/b1/6d/24240bf562e9786dd2799ee0a4a4dadb4ded22510f41b20245099159ac8c/greenlet-3.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bae2728e1897aa8df8cb1af38cd48b3a743aefe29372de7b8b7a9f532501e69f", size = 1645781, upload-time = "2026-07-22T11:51:14.805Z" },
     { url = "https://files.pythonhosted.org/packages/c1/5a/442ab1a9ef7ca6bf7210e5397a95972206a91a31033a03c8900866a10039/greenlet-3.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ca5726c0b08ca35ae873557266a78b2c3f3b2b7d7401aa5ff886c2045dd0111c", size = 247133, upload-time = "2026-07-22T11:39:20.661Z" },
@@ -289,7 +293,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
     { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
     { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
     { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
     { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
     { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
@@ -297,14 +303,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
     { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
     { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
     { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
     { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
     { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
     { url = "https://files.pythonhosted.org/packages/90/03/e3f96dfc100261a29545ddc8270cafe58f9195b6651466910e820910de77/greenlet-3.5.4-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:178111881dd7a6c946471fda85485ec796e1043c2b939f694b096e2ecf986809", size = 296076, upload-time = "2026-07-22T11:39:38.364Z" },
     { url = "https://files.pythonhosted.org/packages/a4/3d/da52d208e5c977bce8667e784729e584e38b5785f4c1ec0f4c836e9a1c42/greenlet-3.5.4-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d92df08dd65fede97fc37aad36c2e9dcda3b31c467f8e0c2c096456cb818e927", size = 666870, upload-time = "2026-07-22T12:26:46.691Z" },
     { url = "https://files.pythonhosted.org/packages/2d/8a/7e6dee25cb8a8cf9b362c8e597cc269593378bd916f16c736c059a52e85a/greenlet-3.5.4-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99e8f8c4ebc4fd80aa26c1280ae9ad43a0976e786349703a181cf0bae60413e5", size = 677678, upload-time = "2026-07-22T12:29:07.508Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a7/dafc7415d430b0a43a16396eb49ecb3b62fd720877fb259cc4dcfaf5f31e/greenlet-3.5.4-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f17e362d78e37559e0506c5a7d066bdd45073c36a0127a543e8a0df27242ff3", size = 681428, upload-time = "2026-07-22T12:43:49.623Z" },
     { url = "https://files.pythonhosted.org/packages/6c/21/5a38699fa45de749e3857d93b8f07e4c20489e77c2d35d915a2e1c456606/greenlet-3.5.4-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:394de08dad5ffcb1f50c2159d93e398d9d2da3ed437645eaa54771fa720db9f0", size = 676067, upload-time = "2026-07-22T11:51:18.163Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d9/6298f3432de301d4718766cf934bd73c418c73f81fbb77247319364b0d96/greenlet-3.5.4-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:cd320d998cbaa032932830448e39abf3c6a12901295e386e8114db926e10cffb", size = 487446, upload-time = "2026-07-22T12:39:57.044Z" },
     { url = "https://files.pythonhosted.org/packages/5e/ba/863116ab8ff1ca7a729e327800268939d182db47aa433db70e216e7d9194/greenlet-3.5.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:c883d61f2282d72c767a14936641b3efcbde9d82f1080712aaea0b1d3126cb88", size = 1633489, upload-time = "2026-07-22T12:25:09.605Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7466ced82818d6132462d7f26b3f83c66ea15d2b193a6c0088d558ed7d95/greenlet-3.5.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2a924f15d17957e252a810acefcb5942f5ca712298e8b6fcaed9a307d357522c", size = 1696584, upload-time = "2026-07-22T11:51:21.304Z" },
     { url = "https://files.pythonhosted.org/packages/f9/4d/55b638489260065de9ffce606c8b5d04507bef705de4b212a0c3d6a1a0df/greenlet-3.5.4-cp315-cp315-win_amd64.whl", hash = "sha256:ed17e5f3420360d5b459de8462efb52060399a5326a613d4cde31cef63ef95da", size = 248297, upload-time = "2026-07-22T11:42:04.055Z" },
@@ -312,7 +322,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/66/7c87ed9cdbf1d49c2c6cd1c7b9dd4d16c33b24235ca03972293a1876b30c/greenlet-3.5.4-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:1833637f17d5e7472548a48575c394fe39f1b1890d676d162d86593610f44d8c", size = 306487, upload-time = "2026-07-22T11:41:25.118Z" },
     { url = "https://files.pythonhosted.org/packages/5b/05/0a4201e7c0054866eefc05da234f236dd4c950d0fbf9ca0517141f01b269/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12cda9122e03341f1cb6b8207a19d7a9d375e52f1b4e9243918375f40fd7b4b9", size = 676479, upload-time = "2026-07-22T12:26:48.129Z" },
     { url = "https://files.pythonhosted.org/packages/3d/c0/4b6b8c5a3aec70f0649cd89662d120fdd6421e2bdc8e3b15c3ab5ec568d8/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d83ae0e32d14957ab7170785a20f582635c8474deab1bfbb552b17e769a6ce25", size = 684321, upload-time = "2026-07-22T12:29:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/88/15/0b167aeea95285b0e654ddce651922f666c089363c2ec528ca8b9a9ba74f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:123aa379c962ed5fe90a880327e0c3066124ac64ec99e12a238be9fd8eb3db3d", size = 685995, upload-time = "2026-07-22T12:43:50.993Z" },
     { url = "https://files.pythonhosted.org/packages/24/c9/b49c31c9a972eee91e260445770e922244a7efc542697f51a012ec046d0f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f1467de1bb767f75db0aa34c195e3a496d8d1278c796e70c24ce205d3e99cde", size = 681293, upload-time = "2026-07-22T11:51:20.43Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/c023ec337f32ff505be7db759c80d98f0532bb94d0c6fa13645efe9bee2e/greenlet-3.5.4-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:adf2244d7f69409925a8f22ed22cc5f93cdfe5c9dc87ff3476be2c2aaae61a05", size = 516928, upload-time = "2026-07-22T12:39:58.359Z" },
     { url = "https://files.pythonhosted.org/packages/95/6f/7f2d4653770500eee667866016d42d7a68e3d3462f80df6b8e3fcd48a0eb/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0fa53040b78b578120eecdc0265e3f1051487cc425d11a2b7c761daadf4feaa8", size = 1642474, upload-time = "2026-07-22T12:25:10.819Z" },
     { url = "https://files.pythonhosted.org/packages/5a/d8/8cba31036a4caae448087ba5d150660ab03b4a0f54d9150f6495a3be7262/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:60e0bc961d367df506660e9ac0177a76bc6d81305300704b0977d1634f76efe2", size = 1701012, upload-time = "2026-07-22T11:51:23.17Z" },
     { url = "https://files.pythonhosted.org/packages/e3/cd/3f77a4cce3bae631b08eb52f53a82a976669600337e21dfdba811cb50267/greenlet-3.5.4-cp315-cp315t-win_amd64.whl", hash = "sha256:f680e549edb3eaf21eea4e7fe101e15ec180c74b7879ab46adc080f22d4015d2", size = 251977, upload-time = "2026-07-22T11:41:38.125Z" },
@@ -643,10 +655,10 @@ name = "milvus-lite"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/d0/3edb31f832287557c8a8bb0515aec2c73265512040dcd4fc43d747722d11/milvus_lite-3.1.1.tar.gz", hash = "sha256:0cbf8386a2e99b6464a5eda14cf8e31934b0e287e36c831e293aee614d9efc2e", size = 647172, upload-time = "2026-07-27T05:03:56.834Z" }
 wheels = [


### PR DESCRIPTION
Discovered when latest version of ruff was run on dependency updates. This PR combines both manual edits, automatic edits from running `uv run ruff check --fix` and Claude-created fixes.